### PR TITLE
feat: 캘린더 메인 화면 UI 초안

### DIFF
--- a/lib/calendar_day_cell.dart
+++ b/lib/calendar_day_cell.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class CalendarDayCell extends StatelessWidget {
+  final double width;
+  final double height;
+  final String dayText;
+  final bool hasRecord;
+  final VoidCallback onTap;
+
+  const CalendarDayCell({
+    super.key,
+    required this.width,
+    required this.height,
+    required this.dayText,
+    required this.hasRecord,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          color: hasRecord ? Colors.blue : Colors.white,
+          border: Border.all(color: Colors.black),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        alignment: Alignment.topLeft,
+        child: Text(dayText),
+      ),
+    );
+  }
+}

--- a/lib/calendar_day_cell.dart
+++ b/lib/calendar_day_cell.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
 
 class CalendarDayCell extends StatelessWidget {
-  final double width;
-  final double height;
   final String dayText;
   final bool hasRecord;
   final VoidCallback onTap;
 
   const CalendarDayCell({
     super.key,
-    required this.width,
-    required this.height,
     required this.dayText,
     required this.hasRecord,
     required this.onTap,
@@ -20,16 +16,17 @@ class CalendarDayCell extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
-      child: Container(
-        width: width,
-        height: height,
-        decoration: BoxDecoration(
-          color: hasRecord ? Colors.blue : Colors.white,
-          border: Border.all(color: Colors.black),
-          borderRadius: BorderRadius.circular(8),
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: Container(
+          decoration: BoxDecoration(
+            color: hasRecord ? Colors.deepPurple : Colors.white,
+            border: Border.all(color: Colors.black),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          alignment: Alignment.topLeft,
+          child: Text(dayText),
         ),
-        alignment: Alignment.topLeft,
-        child: Text(dayText),
       ),
     );
   }

--- a/lib/empty_cell.dart
+++ b/lib/empty_cell.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class EmptyCell extends StatelessWidget {
+  const EmptyCell({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const AspectRatio(
+      aspectRatio: 1,
+      child: SizedBox.shrink(),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,125 +1,25 @@
 import 'package:flutter/material.dart';
+import 'my_calendar_page.dart';
+
+// TODO: Let the user set a goal
+String kUserGoal = 'User\'s goal';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const Haenaedda());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class Haenaedda extends StatelessWidget {
+  const Haenaedda({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'HAENAEDDA — I did it',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a blue toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      home: MyCalendarPage(title: kUserGoal),
     );
   }
 }

--- a/lib/my_calendar_page.dart
+++ b/lib/my_calendar_page.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import 'calendar_day_cell.dart';
+import 'empty_cell.dart';
+
+class MyCalendarPage extends StatefulWidget {
+  final String title;
+
+  const MyCalendarPage({super.key, required this.title});
+
+  @override
+  State<MyCalendarPage> createState() => _MyCalendarPageState();
+}
+
+class _MyCalendarPageState extends State<MyCalendarPage> {
+  final daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+
+  @override
+  Widget build(BuildContext context) {
+    int year = DateTime.now().year;
+    int month = DateTime.now().month;
+    int firstWeekday = DateTime(year, month, 1).weekday % 7;
+    int totalDaysOfMonth = DateTime(year, month + 1, 0).day;
+    int leadingBlanks = firstWeekday;
+    int totalCells = leadingBlanks + totalDaysOfMonth;
+    int trailingBlanks = (7 - totalCells % 7) % 7;
+    int totalCellsCount = totalCells + trailingBlanks;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: Text(widget.title),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            const SizedBox(height: 20),
+            Text(
+              '$year년 $month월',
+              style: const TextStyle(fontSize: 20),
+            ),
+            const SizedBox(height: 20),
+            Row(
+              children: List.generate(daysOfWeek.length, (index) {
+                return Expanded(
+                  child: Text(
+                    daysOfWeek[index],
+                    style: const TextStyle(fontSize: 15),
+                    textAlign: TextAlign.center,
+                  ),
+                );
+              }),
+            ),
+            const SizedBox(height: 10),
+            GridView.count(
+              shrinkWrap: true,
+              crossAxisCount: 7,
+              childAspectRatio: 1,
+              mainAxisSpacing: 10,
+              crossAxisSpacing: 8,
+              children: List.generate(totalCellsCount, (index) {
+                if (index < leadingBlanks) {
+                  return const EmptyCell();
+                } else if (index < leadingBlanks + totalDaysOfMonth) {
+                  int day = index - leadingBlanks + 1;
+                  return CalendarDayCell(
+                    dayText: '$day',
+                    hasRecord: true,
+                    onTap: () {},
+                  );
+                } else {
+                  return const EmptyCell();
+                }
+              }),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:haenaedda/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const Haenaedda());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## 작업 내용 
- my_calendar_page.dart로 분리 
- 달력 구성할 데이터 임시 변수 추가 
- gridView의 cell이 될 CalendarDayCell과 달력의 빈 공간을 채울 빈 cell 생성 
- 사용자가 저장할 목표를 담을 변수를 kUserGoal 전역변수로 임시 생성 
- main.dart 내 불필요한 주석 제거 및 앱 이름 변경 