### PR TITLE
Feature: 달력 네비게이션 바 기능 구현

### DIFF
--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -58,6 +58,15 @@ class RecordProvider extends ChangeNotifier {
     }
   }
 
+  DateTime getFirstRecordedDate() {
+    if (_recordsByGoalId.isEmpty) {
+      return DateTime.now();
+    }
+    final allDates = _recordsByGoalId.values.expand((dates) => dates).toList();
+    allDates.sort((a, b) => a.compareTo(b));
+    return allDates.first;
+  }
+
   void toggleRecord(String goalId, DateTime date) {
     final goalRecords = _recordsByGoalId[goalId] ?? <DateTime>{};
     if (goalRecords.contains(date)) {

--- a/lib/ui/goal_calendar/header_section/calendar_header_section.dart
+++ b/lib/ui/goal_calendar/header_section/calendar_header_section.dart
@@ -72,7 +72,7 @@ class _CalendarHeaderSectionState extends State<CalendarHeaderSection> {
                 },
               ),
         const SizedBox(height: 24),
-        MonthNavigationBar(date: widget.date),
+        MonthNavigationBar(referenceDate: widget.date),
       ],
     );
   }

--- a/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:haenaedda/provider/record_provider.dart';
 
 class MonthNavigationBar extends StatefulWidget {
-  final DateTime date;
+  final DateTime referenceDate;
 
   const MonthNavigationBar({
     super.key,
-    required this.date,
+    required this.referenceDate,
   });
 
   @override
@@ -13,6 +16,52 @@ class MonthNavigationBar extends StatefulWidget {
 }
 
 class _MonthNavigationBarState extends State<MonthNavigationBar> {
+  late DateTime _focusedDate;
+  DateTime? _firstRecordedDate;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusedDate = widget.referenceDate;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _initFirstRecordedDateIfNeeded();
+  }
+
+  void _initFirstRecordedDateIfNeeded() {
+    _firstRecordedDate ??=
+        context.read<RecordProvider>().getFirstRecordedDate();
+  }
+
+  bool get isAtFirstRecordedMonth {
+    _initFirstRecordedDateIfNeeded();
+    return _focusedDate.year == _firstRecordedDate!.year &&
+        _focusedDate.month == _firstRecordedDate!.month;
+  }
+
+  bool get isAtReferenceMonth =>
+      _focusedDate.year == widget.referenceDate.year &&
+      _focusedDate.month == widget.referenceDate.month;
+
+  void _goToPreviousMonth() {
+    if (!isAtFirstRecordedMonth) {
+      setState(() {
+        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month - 1);
+      });
+    }
+  }
+
+  void _goToNextMonth() {
+    if (!isAtReferenceMonth) {
+      setState(() {
+        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month + 1);
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(

--- a/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
@@ -64,36 +64,51 @@ class _MonthNavigationBarState extends State<MonthNavigationBar> {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        IconButton(
-          // TODO: implement navigation to previous and next months
-          onPressed: () {},
-          icon: const Icon(Icons.chevron_left),
-          color: Theme.of(context).colorScheme.onBackground,
-          splashColor: Colors.transparent,
-          highlightColor: Colors.transparent,
-          hoverColor: Colors.transparent,
-          focusColor: Colors.transparent,
-        ),
-        Text(
-          '${widget.date.year}.${widget.date.month}',
-          style: TextStyle(
+    return ConstrainedBox(
+      constraints: const BoxConstraints(
+        minHeight: 48,
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (!isAtFirstRecordedMonth)
+            IconButton(
+              onPressed: _goToPreviousMonth,
+              icon: const Icon(Icons.chevron_left),
               color: Theme.of(context).colorScheme.onBackground,
-              fontWeight: FontWeight.bold),
-        ),
-        IconButton(
-          // TODO: implement navigation to previous and next months
-          onPressed: () {},
-          icon: const Icon(Icons.chevron_right),
-          color: Theme.of(context).colorScheme.onBackground,
-          splashColor: Colors.transparent,
-          highlightColor: Colors.transparent,
-          hoverColor: Colors.transparent,
-          focusColor: Colors.transparent,
-        ),
-      ],
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              hoverColor: Colors.transparent,
+              focusColor: Colors.transparent,
+            ),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.3,
+            ),
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                '${_focusedDate.year}.${_focusedDate.month.toString().padLeft(2, '0')}',
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onBackground,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+          ),
+          if (!isAtReferenceMonth)
+            IconButton(
+              onPressed: _goToNextMonth,
+              icon: const Icon(Icons.chevron_right),
+              color: Theme.of(context).colorScheme.onBackground,
+              splashColor: Colors.transparent,
+              highlightColor: Colors.transparent,
+              hoverColor: Colors.transparent,
+              focusColor: Colors.transparent,
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/goal_calendar/my_calendar_page.dart
+++ b/lib/ui/goal_calendar/my_calendar_page.dart
@@ -42,7 +42,7 @@ class _MyCalendarPageState extends State<MyCalendarPage> {
                 // TODO: Implement the save functionality
                 onGoalEditSubmitted: (String value) {},
               ),
-              const SizedBox(height: 24),
+              const SizedBox(height: 16),
               const Divider(thickness: 1),
               const SizedBox(height: 32),
               Row(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  assets:
+  # assets:
     #  - assets/did_it_stamp_kor.png
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION

## 변경 목적
- 기획 의도에 맞게 사용자가 목표를 실제로 기록한 달에만 집중할 수 있도록 달력 이동 동작을 제한했습니다.
- 텍스트 레이아웃이 깨지지 않도록 크기 제한을 추가했습니다.

## 주요 변경 사항 
- 달력 네비게이션 바에 이전/다음 달 이동 기능 추가
- 첫 목표 생성 달부터 가장 최근 기록된 달까지만 이동 가능하도록 이동 버튼 숨김 처리
    
    ![스크린샷 2025-05-19 15 08 54](https://github.com/user-attachments/assets/1e15f5ca-8841-4ee6-b5ad-c71d101dce9a)

- 달력 상단 월 표시 텍스트 크기 제한

## 기대 효과 
- 목표 기록 범위 내 이동 제한으로 사용자 집중도 향상
- 과도한 크기로 인한 레이아웃 깨짐 방지 및 일관된 레이아웃 유지

## 다음 계획
- 목표 변경 저장 기능 구현