### PR TITLE
Refactor: BoxShadow offset 네이밍을 방향 기준으로 변경 

### DIFF
--- a/lib/constants/neumorphic_theme.dart
+++ b/lib/constants/neumorphic_theme.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
 class NeumorphicTheme {
+  static const Offset topLeftOffset = Offset(-2, -2);
+  static const Offset deepTopLeftOffset = Offset(-4, -4);
+  static const Offset bottomRightOffset = Offset(2, 2);
+  static const Offset deepBottomRightOffset = Offset(4, 4);
+
   static const double blurRadius = 8;
-  static const Offset topLeftShadowOffset = Offset(-4, -4);
-  static const Offset bottomRightShadowOffset = Offset(4, 4);
   static BorderRadius defaultBorderRadius = BorderRadius.circular(12);
 
   /// Pressed (Concave) Effect - Light Mode Only
@@ -11,16 +14,16 @@ class NeumorphicTheme {
   static BoxDecoration pressedBoxDecoration(BuildContext context) {
     return BoxDecoration(
       color: Theme.of(context).colorScheme.background,
-      borderRadius: BorderRadius.circular(12),
+      borderRadius: defaultBorderRadius,
       boxShadow: [
         BoxShadow(
           color: Colors.black.withOpacity(0.05),
-          offset: topLeftShadowOffset,
+          offset: deepTopLeftOffset,
           blurRadius: blurRadius,
         ),
         BoxShadow(
           color: Colors.white.withOpacity(0.7),
-          offset: bottomRightShadowOffset,
+          offset: deepBottomRightOffset,
           blurRadius: blurRadius,
         ),
       ],
@@ -36,31 +39,31 @@ class NeumorphicTheme {
       boxShadow: [
         BoxShadow(
           color: Colors.black.withOpacity(0.05),
-          offset: bottomRightShadowOffset,
+          offset: deepBottomRightOffset,
           blurRadius: blurRadius,
         ),
         BoxShadow(
           color: Colors.white.withOpacity(0.7),
-          offset: topLeftShadowOffset,
+          offset: deepTopLeftOffset,
           blurRadius: blurRadius,
         ),
       ],
     );
   }
 
-  static BoxDecoration raisedTileBoxDecoration(BuildContext context) {
+  static BoxDecoration raisedSettingTileBoxDecoration(BuildContext context) {
     return BoxDecoration(
       color: Theme.of(context).colorScheme.background,
       borderRadius: BorderRadius.circular(16),
       boxShadow: [
         BoxShadow(
           color: Colors.black.withOpacity(0.07),
-          offset: const Offset(2, 2),
+          offset: bottomRightOffset,
           blurRadius: 4,
         ),
         BoxShadow(
           color: Colors.white.withOpacity(0.6),
-          offset: const Offset(-2, -2),
+          offset: topLeftOffset,
           blurRadius: 6,
         ),
       ],
@@ -76,12 +79,12 @@ class NeumorphicTheme {
       boxShadow: [
         BoxShadow(
           color: Colors.white.withOpacity(0.7),
-          offset: topLeftShadowOffset,
+          offset: deepTopLeftOffset,
           blurRadius: blurRadius,
         ),
         BoxShadow(
           color: Colors.black.withOpacity(0.1),
-          offset: bottomRightShadowOffset,
+          offset: deepBottomRightOffset,
           blurRadius: blurRadius,
         ),
       ],
@@ -96,12 +99,12 @@ class NeumorphicTheme {
       boxShadow: [
         BoxShadow(
           color: Colors.white.withOpacity(0.7),
-          offset: const Offset(2, 2),
+          offset: bottomRightOffset,
           blurRadius: blurRadius,
         ),
         BoxShadow(
           color: Colors.black.withOpacity(0.1),
-          offset: const Offset(-2, -2),
+          offset: topLeftOffset,
           blurRadius: blurRadius,
         ),
       ],

--- a/lib/ui/settings/neumorphic_settings_tile.dart
+++ b/lib/ui/settings/neumorphic_settings_tile.dart
@@ -22,7 +22,7 @@ class NeumorphicSettingsTile extends StatelessWidget {
         constraints: const BoxConstraints(minHeight: 48),
         margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-        decoration: NeumorphicTheme.raisedTileBoxDecoration(context),
+        decoration: NeumorphicTheme.raisedSettingTileBoxDecoration(context),
         alignment: Alignment.centerLeft,
         child: DefaultTextStyle(
           style: TextStyle(


### PR DESCRIPTION
### 변경 목적
- 기존에는 BoxShadow offset 변수명이 방향+역할 기반(`topLeftShadow`)으로 되어 있어,
스타일에 따라 highlight일 때도 같은 이름을 사용하는 문제가 있었습니다.  
- 움푹 들어가보이는, 볼록 나와보이는 상황 모두에서 쓰이기 때문에 이름에서 역할은 제거하고, 방향 중심(`topLeft`, `bottomRight`)의 네이밍으로 변경하여 명확성을 높였습니다.
- Offset(2, 2)도 사용하게 되어 기존의 Offset(4, 4)에는 `deep`을 추가했습니다. 

### 주요 변경 사항
- `-ShadowOffset` 역할 기반 네이밍 제거
- `topLeftOffset`, `bottomRightOffset`, `deepTopLeftOffset` 등의 물리적 방향 기반 상수로 대체

### 기대 효과
- 유지보수성과 시각 구조 표현의 일관성 향상