### PR TITLE
Feature: 목표 초기화 로직 및 안내 다이얼로그 추가 

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -28,5 +28,13 @@
     "resetRecordsMessage": "Resetting will delete all your records.\nThis action can’t be undone.",
     "@resetRecordsMessage": {
         "description": "Body text of the confirmation dialog warning the user that all records will be deleted and that this action is irreversible."
+    },
+    "resetSuccess": "Records deleted.",
+    "@resetSuccess": {
+        "description": "Message shown after user successfully deletes goal records."
+    },
+    "resetFailure": "Couldn't delete records.",
+    "@resetFailure": {
+        "description": "Error message shown when goal record deletion fails."
     }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -24,5 +24,9 @@
     "shortWeekdays": "S,M,T,W,T,F,S",
     "@shortWeekdays": {
         "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
+    },
+    "resetRecordsMessage": "Resetting will delete all your records.\nThis action can’t be undone.",
+    "@resetRecordsMessage": {
+        "description": "Body text of the confirmation dialog warning the user that all records will be deleted and that this action is irreversible."
     }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -16,5 +16,9 @@
     "shortWeekdays": "월,화,수,목,금,토,일",
     "@shortWeekdays": {
         "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
+    },
+    "resetRecordsMessage": "초기화하면 모든 기록이 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.",
+    "@resetRecordsMessage": {
+        "description": "Body text of the confirmation dialog warning the user that all records will be deleted and that this action is irreversible."
     }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -20,5 +20,13 @@
     "resetRecordsMessage": "초기화하면 모든 기록이 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.",
     "@resetRecordsMessage": {
         "description": "Body text of the confirmation dialog warning the user that all records will be deleted and that this action is irreversible."
+    },
+    "resetSuccess": "기록이 삭제되었습니다.",
+    "@resetSuccess": {
+        "description": "Message shown after user successfully deletes goal records."
+    },
+    "resetFailure": "기록 삭제에 실패했습니다.",
+    "@resetFailure": {
+        "description": "Error message shown when goal record deletion fails."
     }
 }

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -159,4 +159,18 @@ class RecordProvider extends ChangeNotifier {
       await prefs.setString(entry.key, dates);
     }
   }
+
+  Future<bool> clearGoalRecords(String goalId) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final success = await prefs.remove(goalId);
+      if (!success) return false;
+      _recordsByGoalId.remove(goalId);
+      notifyListeners();
+      return true;
+    } catch (e) {
+      debugPrint('Failed to delete records. id: $goalId');
+      return false;
+    }
+  }
 }

--- a/lib/ui/goal_calendar/header_section/calendar_header_section.dart
+++ b/lib/ui/goal_calendar/header_section/calendar_header_section.dart
@@ -61,6 +61,7 @@ class _CalendarHeaderSectionState extends State<CalendarHeaderSection> {
                 },
               )
             : GoalDisplayText(
+                goal: widget.goal,
                 buttonHeight: buttonHeight,
                 controller: _controller,
                 goalTextStyle: _goalTextStyle,

--- a/lib/ui/goal_calendar/header_section/goal_display_text.dart
+++ b/lib/ui/goal_calendar/header_section/goal_display_text.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:haenaedda/model/goal.dart';
 
 import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/ui/settings/settings_button.dart';
 
 class GoalDisplayText extends StatelessWidget {
+  final Goal goal;
   final double buttonHeight;
   final TextStyle goalTextStyle;
   final VoidCallback onStartEditing;
@@ -12,6 +14,7 @@ class GoalDisplayText extends StatelessWidget {
 
   const GoalDisplayText({
     super.key,
+    required this.goal,
     required this.buttonHeight,
     required this.goalTextStyle,
     required this.onStartEditing,
@@ -42,7 +45,7 @@ class GoalDisplayText extends StatelessWidget {
             ),
           ),
         ),
-        const SettingButton(),
+        SettingButton(goal: goal),
       ],
     );
   }

--- a/lib/ui/settings/handlers/reset_goal_handler.dart
+++ b/lib/ui/settings/handlers/reset_goal_handler.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:haenaedda/gen_l10n/app_localizations.dart';
+import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/provider/record_provider.dart';
+
+Future<void> showResetFailureDialog(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (_) => AlertDialog(
+      title: Text(AppLocalizations.of(context)!.cancel),
+      content: Text(AppLocalizations.of(context)!.resetFailure),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(AppLocalizations.of(context)!.confirm),
+        ),
+      ],
+    ),
+  );
+}
+
+Future<bool?> showResetConfirmDialog(BuildContext context, Goal goal) async {
+  return await showDialog<bool?>(
+    context: context,
+    builder: (context) => AlertDialog(
+      contentPadding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
+      actionsPadding: const EdgeInsets.fromLTRB(0, 16, 16, 16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      content: Text(
+        AppLocalizations.of(context)!.resetRecordsMessage,
+        style: const TextStyle(fontSize: 16, height: 1.5),
+        textAlign: TextAlign.center,
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(
+            AppLocalizations.of(context)!.cancel,
+            style: const TextStyle(fontSize: 16),
+          ),
+        ),
+        TextButton(
+          onPressed: () async {
+            final provider = context.read<RecordProvider>();
+            final succeeded = await provider.clearGoalRecords(goal.id);
+            if (!context.mounted) return;
+            if (succeeded) {
+              Navigator.of(context).pop(true);
+            }
+          },
+          child: Text(
+            AppLocalizations.of(context)!.reset,
+            style: TextStyle(
+              fontSize: 16,
+              color: Theme.of(context).colorScheme.error,
+            ),
+          ),
+        ),
+      ],
+      actionsAlignment: MainAxisAlignment.center,
+    ),
+  );
+}
+
+Future<void> onResetButtonTap(BuildContext context, Goal goal) async {
+  // Step 1: Ask user to confirm reset
+  if (!context.mounted) return;
+  final confirmed = await showResetConfirmDialog(context, goal);
+  if (!context.mounted || confirmed != true) return;
+
+  // Step 2: Try to clear goal records
+  final succeeded =
+      await context.read<RecordProvider>().clearGoalRecords(goal.id);
+  if (!context.mounted) return;
+
+  // Step 3: Handle result
+  if (succeeded) {
+    Navigator.of(context).pop();
+  } else {
+    await showResetFailureDialog(context);
+  }
+}

--- a/lib/ui/settings/settings_bottom_modal.dart
+++ b/lib/ui/settings/settings_bottom_modal.dart
@@ -1,51 +1,22 @@
 import 'package:flutter/material.dart';
+
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
+import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/ui/settings/handlers/reset_goal_handler.dart';
 import 'package:haenaedda/ui/settings/neumorphic_settings_tile.dart';
 import 'package:haenaedda/ui/widgets/modal_action_icon_buttons.dart';
 import 'package:haenaedda/ui/widgets/section_divider.dart';
 
-class SettingsBottomModal extends StatelessWidget {
-  const SettingsBottomModal({super.key});
+class SettingsBottomModal extends StatefulWidget {
+  final Goal goal;
 
-  void _onResetTap(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          contentPadding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
-          actionsPadding: const EdgeInsets.fromLTRB(0, 16, 16, 16),
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-          content: Text(
-            AppLocalizations.of(context)!.resetRecordsMessage,
-            style: const TextStyle(fontSize: 16, height: 1.5),
-            textAlign: TextAlign.center,
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(
-                AppLocalizations.of(context)!.cancel,
-                style: const TextStyle(fontSize: 16.0),
-              ),
-            ),
-            TextButton(
-              onPressed: () {},
-              child: Text(
-                AppLocalizations.of(context)!.reset,
-                style: TextStyle(
-                  fontSize: 16.0,
-                  color: Theme.of(context).colorScheme.error,
-                ),
-              ),
-            ),
-          ],
-          actionsAlignment: MainAxisAlignment.center,
-        );
-      },
-    );
-  }
+  const SettingsBottomModal({super.key, required this.goal});
 
+  @override
+  State<SettingsBottomModal> createState() => _SettingsBottomModalState();
+}
+
+class _SettingsBottomModalState extends State<SettingsBottomModal> {
   @override
   Widget build(BuildContext context) {
     final backgroundColor = Theme.of(context).colorScheme.surface;
@@ -101,7 +72,7 @@ class SettingsBottomModal extends StatelessWidget {
                   const SizedBox(height: 8.0),
                   NeumorphicSettingsTile(
                     title: AppLocalizations.of(context)!.resetSavedGoals,
-                    onTap: () => _onResetTap(context),
+                    onTap: () => onResetButtonTap(context, widget.goal),
                   ),
                 ],
               ),

--- a/lib/ui/settings/settings_bottom_modal.dart
+++ b/lib/ui/settings/settings_bottom_modal.dart
@@ -7,6 +7,45 @@ import 'package:haenaedda/ui/widgets/section_divider.dart';
 class SettingsBottomModal extends StatelessWidget {
   const SettingsBottomModal({super.key});
 
+  void _onResetTap(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          contentPadding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
+          actionsPadding: const EdgeInsets.fromLTRB(0, 16, 16, 16),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+          content: Text(
+            AppLocalizations.of(context)!.resetRecordsMessage,
+            style: const TextStyle(fontSize: 16, height: 1.5),
+            textAlign: TextAlign.center,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(
+                AppLocalizations.of(context)!.cancel,
+                style: const TextStyle(fontSize: 16.0),
+              ),
+            ),
+            TextButton(
+              onPressed: () {},
+              child: Text(
+                AppLocalizations.of(context)!.reset,
+                style: TextStyle(
+                  fontSize: 16.0,
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+            ),
+          ],
+          actionsAlignment: MainAxisAlignment.center,
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final backgroundColor = Theme.of(context).colorScheme.surface;
@@ -60,10 +99,9 @@ class SettingsBottomModal extends StatelessWidget {
                   ),
                   const SectionDivider(),
                   const SizedBox(height: 8.0),
-                  // TODO: Implement actual action
                   NeumorphicSettingsTile(
                     title: AppLocalizations.of(context)!.resetSavedGoals,
-                    onTap: () {},
+                    onTap: () => _onResetTap(context),
                   ),
                 ],
               ),

--- a/lib/ui/settings/settings_button.dart
+++ b/lib/ui/settings/settings_button.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
+import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/ui/settings/settings_bottom_modal.dart';
 
 class SettingButton extends StatelessWidget {
-  const SettingButton({super.key});
+  final Goal goal;
+
+  const SettingButton({super.key, required this.goal});
 
   @override
   Widget build(BuildContext context) {
@@ -15,9 +18,7 @@ class SettingButton extends StatelessWidget {
           barrierLabel: AppLocalizations.of(context)!.dismiss,
           barrierColor: Colors.black54,
           transitionDuration: const Duration(milliseconds: 300),
-          pageBuilder: (context, _, __) {
-            return const SettingsBottomModal();
-          },
+          pageBuilder: (context, _, __) => SettingsBottomModal(goal: goal),
           transitionBuilder: (context, animation, _, child) {
             final offset = Tween<Offset>(
               begin: const Offset(0, 1),


### PR DESCRIPTION
## 변경 목적
- 기록된 목표를 초기화하는 로직을 추가했습니다.
- 목표 기록이 초기화됨을 사용자에게 명확히 안내하기 위한 안내 다이얼로그 및 로직을 추가했습니다. 

## 주요 변경 사항 
- 목표 초기화 처리 로직(onResetButtonTap), 목표 초기화 처리 재확인 (showResetConfirmDialog), 목표 초기화 실패 안내 (showResetFailureDialog) 함수 구현
- 비동기 작업 중 BuildContext.mounted 체크 로직 추가
- SettingButton, SettingsBottomModal에 Goal 객체 전달하도록 수정

## 기대 효과 
- 사용자가 목표 기록을 직접 초기화할 수 있는 기능 제공
- 사용자가 실수로 데이터를 삭제하지 않도록 확인 절차 마련
- context.mounted 체크하여 런타임 에러 방지
- 설정 화면 내 확장(기능 추가) 가능성 확보

## 다음 계획
- 목표 초기화 후 사용자 피드백 메시지 또는 Snackbar 표시 기능 추가 여부 검토
