### PR TITLE
Feature: 초기화 기능 세분화 (기록만 초기화/목표 전체 초기화 구현)

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -21,13 +21,17 @@
     "@shortWeekdays": {
         "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
     },
-    "resetSuccess": "Records deleted.",
+    "resetSuccess": "Reset completed successfully.",
     "@resetSuccess": {
-        "description": "Message shown after user successfully deletes goal records."
+        "description": "Message shown when the reset operation succeeds (regardless of goal count or type)."
     },
-    "resetFailure": "Couldn't delete records.",
+    "resetFailure": "Reset failed. Please try again.",
     "@resetFailure": {
-        "description": "Error message shown when goal record deletion fails."
+        "description": "Message shown when the reset operation fails completely."
+    },
+    "resetPartialFailureGoal": "Records were deleted, but the goal could not be removed.",
+    "@resetPartialFailureGoal": {
+        "description": "Message shown when records are deleted but the goal deletion fails."
     },
     "resetRecordsOnly": "Reset Records Only",
     "@resetRecordsOnly": {
@@ -37,11 +41,11 @@
     "@resetEntireGoal": {
         "description": "Resets the goal completely including its title and saved records."
     },
-    "resetEntireGoalMessage": "This will reset both the goal and its records.\nDo you want to continue?",
+    "resetEntireGoalMessage": "This will reset both the goal and its records. Do you want to continue?",
     "@resetEntireGoalMessage": {
         "description": "Confirmation message for full reset."
     },
-    "resetRecordsOnlyMessage": "Only the records will be deleted.\nThe goal itself will remain unchanged.",
+    "resetRecordsOnlyMessage": "Only the records will be deleted. The goal itself will remain unchanged.",
     "@resetRecordsOnlyMessage": {
         "description": "Confirmation message for record-only reset."
     }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -17,17 +17,9 @@
     "@goalSetupHint": {
         "description": "Hint shown when no goal is set. Encourages the user to tap to create one."
     },
-    "resetSavedGoals": "Reset Saved Goals",
-    "@resetSavedGoals": {
-        "description": "Resets saved goals."
-    },
     "shortWeekdays": "S,M,T,W,T,F,S",
     "@shortWeekdays": {
         "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
-    },
-    "resetRecordsMessage": "Resetting will delete all your records.\nThis action can’t be undone.",
-    "@resetRecordsMessage": {
-        "description": "Body text of the confirmation dialog warning the user that all records will be deleted and that this action is irreversible."
     },
     "resetSuccess": "Records deleted.",
     "@resetSuccess": {
@@ -36,5 +28,21 @@
     "resetFailure": "Couldn't delete records.",
     "@resetFailure": {
         "description": "Error message shown when goal record deletion fails."
+    },
+    "resetRecordsOnly": "Reset Records Only",
+    "@resetRecordsOnly": {
+        "description": "Resets only the saved records, keeping the goal settings."
+    },
+    "resetEntireGoal": "Reset Entire Goal",
+    "@resetEntireGoal": {
+        "description": "Resets the goal completely including its title and saved records."
+    },
+    "resetEntireGoalMessage": "This will reset both the goal and its records.\nDo you want to continue?",
+    "@resetEntireGoalMessage": {
+        "description": "Confirmation message for full reset."
+    },
+    "resetRecordsOnlyMessage": "Only the records will be deleted.\nThe goal itself will remain unchanged.",
+    "@resetRecordsOnlyMessage": {
+        "description": "Confirmation message for record-only reset."
     }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -13,13 +13,17 @@
     "@shortWeekdays": {
         "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
     },
-    "resetSuccess": "기록이 삭제되었습니다.",
+    "resetSuccess": "초기화가 완료되었습니다.",
     "@resetSuccess": {
-        "description": "Message shown after user successfully deletes goal records."
+        "description": "Message shown after goal or records are successfully reset."
     },
-    "resetFailure": "기록 삭제에 실패했습니다.",
+    "resetFailure": "초기화에 실패했습니다.",
     "@resetFailure": {
-        "description": "Error message shown when goal record deletion fails."
+        "description": "General error message shown when reset operation fails."
+    },
+    "resetPartialFailureGoal": "기록은 삭제되었지만 목표 삭제에는 실패했어요.",
+    "@resetPartialFailureGoal": {
+        "description": "Message shown when records are deleted but goal deletion fails."
     },
     "resetRecordsOnly": "기록만 초기화",
     "@resetRecordsOnly": {
@@ -29,11 +33,11 @@
     "@resetEntireGoal": {
         "description": "Resets the goal completely including its title and saved records."
     },
-    "resetEntireGoalMessage": "목표와 기록이 모두 초기화됩니다.\n계속하시겠어요?",
+    "resetEntireGoalMessage": "목표와 기록이 모두 삭제됩니다. 계속하시겠어요?",
     "@resetEntireGoalMessage": {
         "description": "Confirmation message for full reset."
     },
-    "resetRecordsOnlyMessage": "기록만 삭제되며, 목표는 유지됩니다.",
+    "resetRecordsOnlyMessage": "기록만 삭제되며, 목표는 그대로 유지됩니다.",
     "@resetRecordsOnlyMessage": {
         "description": "Confirmation message for record-only reset."
     }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -9,7 +9,7 @@
     "@goalSetupHint": {
         "description": "Hint shown when no goal is set. Encourages the user to tap to create one."
     },
-    "shortWeekdays": "월,화,수,목,금,토,일",
+    "shortWeekdays": "일,월,화,수,목,금,토",
     "@shortWeekdays": {
         "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
     },

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -9,17 +9,9 @@
     "@goalSetupHint": {
         "description": "Hint shown when no goal is set. Encourages the user to tap to create one."
     },
-    "resetSavedGoals": "저장된 목표 초기화",
-    "@resetSavedGoals": {
-        "description": "Resets saved goals."
-    },
     "shortWeekdays": "월,화,수,목,금,토,일",
     "@shortWeekdays": {
         "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
-    },
-    "resetRecordsMessage": "초기화하면 모든 기록이 삭제됩니다.\n이 작업은 되돌릴 수 없습니다.",
-    "@resetRecordsMessage": {
-        "description": "Body text of the confirmation dialog warning the user that all records will be deleted and that this action is irreversible."
     },
     "resetSuccess": "기록이 삭제되었습니다.",
     "@resetSuccess": {
@@ -28,5 +20,21 @@
     "resetFailure": "기록 삭제에 실패했습니다.",
     "@resetFailure": {
         "description": "Error message shown when goal record deletion fails."
+    },
+    "resetRecordsOnly": "기록만 초기화",
+    "@resetRecordsOnly": {
+        "description": "Resets only the saved records, keeping the goal settings."
+    },
+    "resetEntireGoal": "전체 초기화",
+    "@resetEntireGoal": {
+        "description": "Resets the goal completely including its title and saved records."
+    },
+    "resetEntireGoalMessage": "목표와 기록이 모두 초기화됩니다.\n계속하시겠어요?",
+    "@resetEntireGoalMessage": {
+        "description": "Confirmation message for full reset."
+    },
+    "resetRecordsOnlyMessage": "기록만 삭제되며, 목표는 유지됩니다.",
+    "@resetRecordsOnlyMessage": {
+        "description": "Confirmation message for record-only reset."
     }
 }

--- a/lib/model/reset_type.dart
+++ b/lib/model/reset_type.dart
@@ -1,0 +1,4 @@
+enum ResetType {
+  recordsOnly,
+  entireGoal,
+}

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -25,6 +25,12 @@ enum RenameGoalResult {
   saveFailed,
 }
 
+enum ResetEntireGoalResult {
+  success,
+  recordFailed,
+  goalFailed,
+}
+
 class RecordProvider extends ChangeNotifier {
   List<Goal> _goals = [];
   final Map<String, Set<DateTime>> _recordsByGoalId = {};
@@ -200,9 +206,22 @@ class RecordProvider extends ChangeNotifier {
     }
   }
 
-  Future<bool> resetEntireGoal(String goalId) async {
+  Future<ResetEntireGoalResult> resetEntireGoal(String goalId) async {
     final recordsCleared = await removeRecordsOnly(goalId);
+    if (!recordsCleared) return ResetEntireGoalResult.recordFailed;
+
     final goalCleared = await removeGoal(goalId);
-    return recordsCleared && goalCleared;
+    if (!goalCleared) return ResetEntireGoalResult.goalFailed;
+
+    return ResetEntireGoalResult.success;
+  }
+
+  // TODO:
+  Future<void> createTemporaryGoalIfAbsent() async {
+    if (_goals.isEmpty) {
+      final newGoal = Goal(getNextGoalId(), '');
+      _goals.add(newGoal);
+      await saveGoals();
+    }
   }
 }

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -34,6 +34,11 @@ class RecordProvider extends ChangeNotifier {
 
   Set<DateTime> getRecords(String goal) => _recordsByGoalId[goal] ?? {};
 
+  Goal? get currentGoal {
+    if (_goals.isEmpty) return null;
+    return _goals.firstWhereOrNull((g) => g.id == _firstDisplayedGoalId);
+  }
+
   bool isGoalsEmpty() => _goals.isEmpty;
 
 // TODO: Currently displayed in ID order, but will switch to order field later.

--- a/lib/ui/goal_calendar/header_section/calendar_header_section.dart
+++ b/lib/ui/goal_calendar/header_section/calendar_header_section.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/header_section/goal_display_text.dart';
 import 'package:haenaedda/ui/goal_calendar/header_section/goal_edit_field.dart';
 import 'package:haenaedda/ui/goal_calendar/header_section/month_navigation_bar.dart';
@@ -37,6 +39,13 @@ class _CalendarHeaderSectionState extends State<CalendarHeaderSection> {
   void initState() {
     super.initState();
     _controller = TextEditingController(text: widget.goal.title);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final goal = context.watch<RecordProvider>().currentGoal;
+    _controller.text = goal?.title ?? '';
   }
 
   @override

--- a/lib/ui/settings/settings_bottom_modal.dart
+++ b/lib/ui/settings/settings_bottom_modal.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/model/reset_type.dart';
 import 'package:haenaedda/ui/settings/handlers/reset_goal_handler.dart';
 import 'package:haenaedda/ui/settings/neumorphic_settings_tile.dart';
 import 'package:haenaedda/ui/widgets/modal_action_icon_buttons.dart';
@@ -71,8 +72,14 @@ class _SettingsBottomModalState extends State<SettingsBottomModal> {
                   const SectionDivider(),
                   const SizedBox(height: 8.0),
                   NeumorphicSettingsTile(
-                    title: AppLocalizations.of(context)!.resetSavedGoals,
-                    onTap: () => onResetButtonTap(context, widget.goal),
+                    title: AppLocalizations.of(context)!.resetRecordsOnly,
+                    onTap: () => onResetButtonTap(
+                        context, widget.goal, ResetType.recordsOnly),
+                  ),
+                  NeumorphicSettingsTile(
+                    title: AppLocalizations.of(context)!.resetEntireGoal,
+                    onTap: () => onResetButtonTap(
+                        context, widget.goal, ResetType.entireGoal),
                   ),
                 ],
               ),


### PR DESCRIPTION
## 변경 목적
- 현재까지는 기록만 초기화되고 있어서 목표까지 전체가 초기화 기능을 구현했습니다.
- 초기화 시 기록 및 목표가 모두 삭제되므로, 빈 데이터로 인해 크래시가 나지 않도록 빈 목표를 자동 생성했습니다.

## 주요 변경 사항
- RecordProvider.resetEntireGoal() 등의 파라미터 타입이나 리턴 타입을 bool → enum (ResetEntireGoalResult, ResetType)으로 변경 
- 삭제 완료 후 _goals가 비었을 경우 createTemporaryGoalIfAbsent() 실행하여 빈 목표 자동 생성 및 초기 화면 등에서 currentGoal이 null일 수 있는 상황 방어
- 삭제 실패 시 ResetType에 따라 구체적인 에러 메시지 출력
- 삭제 다이얼로그 동작 에러 수정 

## 기대 효과
- 사용자가 전체 초기화를 눌러도 앱이 크래시 없이 정상 동작
- 에러 발생 시 사용자에게 정확한 실패 지점 안내
- 추후 목표 관련 기능 확장 시 빈 목표 상태를 안전하게 처리할 수 있는 구조 기반 마련

## 다음 계획
- 임시 목표가 자동 생성되지 않고 화면을 통해 입력받도록 UX 개선 (예: 첫 진입 시 “목표를 입력해 주세요” 안내)
- 다중 목표 지원 검토 
  - 추후 다중 목표 지원 구조에서 삭제 후 다른 목표 자동 포커싱 기능 검토
- 목표 정렬 기준(order 필드) 도입 예정
