### PR TITLE
Chore: l10n key에 메타데이터 추가

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,52 +1,73 @@
 {
     "@@locale": "en",
-    "dismiss": "Dismiss",
-    "reset": "Reset",
     "settings": "Settings",
+    "@settings": {
+        "description": "Label for settings page or button",
+        "type": "text"
+    },
     "confirm": "Confirm",
+    "@confirm": {
+        "description": "Label for confirming an action",
+        "type": "text"
+    },
     "cancel": "Cancel",
+    "@cancel": {
+        "description": "Label for canceling an action",
+        "type": "text"
+    },
+    "dismiss": "Dismiss",
     "@dismiss": {
         "description": "Label for dismissing a modal",
         "type": "text"
     },
+    "reset": "Reset",
     "@reset": {
         "description": "Tile label for resetting settings",
         "type": "text"
     },
     "goalSetupHint": "Tap here to set your goal",
     "@goalSetupHint": {
-        "description": "Hint shown when no goal is set. Encourages the user to tap to create one."
+        "description": "Hint shown when no goal is set. Encourages the user to tap to create one.",
+        "type": "text"
     },
     "shortWeekdays": "S,M,T,W,T,F,S",
     "@shortWeekdays": {
-        "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
+        "description": "Comma-separated list of abbreviated weekdays, starting from Sunday",
+        "type": "text"
     },
     "resetSuccess": "Reset completed successfully.",
     "@resetSuccess": {
-        "description": "Message shown when the reset operation succeeds (regardless of goal count or type)."
+        "description": "Message shown when the reset operation succeeds (regardless of goal count or type).",
+        "type": "text"
     },
     "resetFailure": "Reset failed. Please try again.",
     "@resetFailure": {
-        "description": "Message shown when the reset operation fails completely."
+        "description": "Message shown when the reset operation fails completely.",
+        "type": "text"
     },
     "resetPartialFailureGoal": "Records were deleted, but the goal could not be removed.",
     "@resetPartialFailureGoal": {
-        "description": "Message shown when records are deleted but the goal deletion fails."
+        "description": "Message shown when records are deleted but the goal deletion fails.",
+        "type": "text"
     },
     "resetRecordsOnly": "Reset Records Only",
     "@resetRecordsOnly": {
-        "description": "Resets only the saved records, keeping the goal settings."
+        "description": "Resets only the saved records, keeping the goal settings.",
+        "type": "text"
     },
     "resetEntireGoal": "Reset Entire Goal",
     "@resetEntireGoal": {
-        "description": "Resets the goal completely including its title and saved records."
+        "description": "Resets the goal completely including its title and saved records.",
+        "type": "text"
     },
     "resetEntireGoalMessage": "This will reset both the goal and its records. Do you want to continue?",
     "@resetEntireGoalMessage": {
-        "description": "Confirmation message for full reset."
+        "description": "Confirmation message for full reset.",
+        "type": "text"
     },
     "resetRecordsOnlyMessage": "Only the records will be deleted. The goal itself will remain unchanged.",
     "@resetRecordsOnlyMessage": {
-        "description": "Confirmation message for record-only reset."
+        "description": "Confirmation message for record-only reset.",
+        "type": "text"
     }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -1,44 +1,73 @@
 {
     "@@locale": "ko",
-    "dismiss": "닫기",
-    "reset": "초기화",
     "settings": "설정",
+    "@settings": {
+        "description": "Label for settings page or button",
+        "type": "text"
+    },
     "confirm": "확인",
+    "@confirm": {
+        "description": "Label for confirming an action",
+        "type": "text"
+    },
     "cancel": "취소",
+    "@cancel": {
+        "description": "Label for canceling an action",
+        "type": "text"
+    },
+    "dismiss": "닫기",
+    "@dismiss": {
+        "description": "Label for dismissing a modal",
+        "type": "text"
+    },
+    "reset": "초기화",
+    "@reset": {
+        "description": "Tile label for resetting settings",
+        "type": "text"
+    },
     "goalSetupHint": "눌러서 목표를 설정해보세요",
     "@goalSetupHint": {
-        "description": "Hint shown when no goal is set. Encourages the user to tap to create one."
+        "description": "Hint shown when no goal is set. Encourages the user to tap to create one.",
+        "type": "text"
     },
     "shortWeekdays": "일,월,화,수,목,금,토",
     "@shortWeekdays": {
-        "description": "Comma-separated list of abbreviated weekdays, starting from Sunday"
+        "description": "Comma-separated list of abbreviated weekdays, starting from Sunday",
+        "type": "text"
     },
     "resetSuccess": "초기화가 완료되었습니다.",
     "@resetSuccess": {
-        "description": "Message shown after goal or records are successfully reset."
+        "description": "Message shown after goal or records are successfully reset.",
+        "type": "text"
     },
     "resetFailure": "초기화에 실패했습니다.",
     "@resetFailure": {
-        "description": "General error message shown when reset operation fails."
+        "description": "General error message shown when reset operation fails.",
+        "type": "text"
     },
     "resetPartialFailureGoal": "기록은 삭제되었지만 목표 삭제에는 실패했어요.",
     "@resetPartialFailureGoal": {
-        "description": "Message shown when records are deleted but goal deletion fails."
+        "description": "Message shown when records are deleted but goal deletion fails.",
+        "type": "text"
     },
     "resetRecordsOnly": "기록만 초기화",
     "@resetRecordsOnly": {
-        "description": "Resets only the saved records, keeping the goal settings."
+        "description": "Resets only the saved records, keeping the goal settings.",
+        "type": "text"
     },
     "resetEntireGoal": "전체 초기화",
     "@resetEntireGoal": {
-        "description": "Resets the goal completely including its title and saved records."
+        "description": "Resets the goal completely including its title and saved records.",
+        "type": "text"
     },
     "resetEntireGoalMessage": "목표와 기록이 모두 삭제됩니다. 계속하시겠어요?",
     "@resetEntireGoalMessage": {
-        "description": "Confirmation message for full reset."
+        "description": "Confirmation message for full reset.",
+        "type": "text"
     },
     "resetRecordsOnlyMessage": "기록만 삭제되며, 목표는 그대로 유지됩니다.",
     "@resetRecordsOnlyMessage": {
-        "description": "Confirmation message for record-only reset."
+        "description": "Confirmation message for record-only reset.",
+        "type": "text"
     }
 }


### PR DESCRIPTION
## 변경 목적

- Flutter 로컬라이제이션 .arb 파일 내 일부 키에 메타데이터(key 형식의 설명 및 타입)가 누락되어 있어 추가했습니다. 
- IDE 경고를 제거하고 향후 다국어 번역 시 문맥을 명확히 전달하기 위함입니다.

## 주요 변경 사항
- intl_*.arb 파일 내 `settings`, `confirm`, `cancel` 키에 메타데이터 추가
    - 각 항목에 description 및 `type: "text"` 명시

## 기대 효과
- IDE 경고 제거
- 번역 문맥 명확화로 번역 품질 개선 (로컬라이징 자동화 툴(Lokalise 등) 연동 시 키 설명 표시 가능)

## 다음 계획
- 리드미 문서 보완 