### PR TITLE
Feature: 목표간 (수직 스와이프를 통한) 전환 기능 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/app_theme.dart';
-import 'package:haenaedda/ui/goal_calendar/my_calendar_page.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
 
 void main() {
   runApp(
@@ -27,7 +27,7 @@ class Haenaedda extends StatefulWidget {
 }
 
 class _HaenaeddaState extends State<Haenaedda> {
-  Goal? firstDisplayedGoal;
+  List<Goal>? goals;
 
   @override
   void initState() {
@@ -36,20 +36,21 @@ class _HaenaeddaState extends State<Haenaedda> {
       final recordProvider =
           Provider.of<RecordProvider>(context, listen: false);
 
-      final goal = await recordProvider.initializeAndGetFirstGoal();
+      final sortedGoals = await recordProvider.initializeAndGetGoals();
       if (!mounted) return;
       setState(() {
-        firstDisplayedGoal = goal;
+        goals = sortedGoals;
       });
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    if (firstDisplayedGoal == null) {
+    if (goals == null) {
       return const Center(child: CircularProgressIndicator());
     }
-    final Goal nonNullableGoal = firstDisplayedGoal!;
+    // TODO: Handle null, empty, and valid goal states appropriately after loading.
+    final List<Goal> nonNullableGoals = goals!;
 
     return MaterialApp(
       builder: (context, child) {
@@ -73,8 +74,7 @@ class _HaenaeddaState extends State<Haenaedda> {
         Locale('en'),
         Locale('ko'),
       ],
-      // TODO: Support multi-goal selection and routing later
-      home: MyCalendarPage(goal: nonNullableGoal),
+      home: GoalCalendarPage(goals: nonNullableGoals),
     );
   }
 }

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -145,6 +145,7 @@ class RecordProvider extends ChangeNotifier {
       return RenameGoalResult.notFound;
     }
     goal.title = newGoalTitle;
+    saveGoals();
     notifyListeners();
     return RenameGoalResult.success;
   }
@@ -175,8 +176,9 @@ class RecordProvider extends ChangeNotifier {
       }
 
       final decodedGoalsJson = jsonDecode(loadedGoalsJson);
-      final restoredGoals =
-          decodedGoalsJson.map((e) => Goal.fromJson(e)).toList();
+      final List<Goal> restoredGoals = (decodedGoalsJson as List)
+          .map((e) => Goal.fromJson((e as Map<String, dynamic>)))
+          .toList();
       _goals = restoredGoals;
       _syncSortedGoals();
       notifyListeners();

--- a/lib/ui/goal_calendar/calendar_grid.dart
+++ b/lib/ui/goal_calendar/calendar_grid.dart
@@ -5,12 +5,12 @@ import 'package:haenaedda/model/date_record_set.dart';
 import 'package:haenaedda/ui/goal_calendar/calendar_day_cell.dart';
 import 'package:haenaedda/ui/goal_calendar/empty_cell.dart';
 
-class CalendarScreen extends StatefulWidget {
+class CalendarGrid extends StatefulWidget {
   final CalendarGridLayout dateLayout;
   final DateRecordSet selectedDates;
   final void Function(DateTime) onCellTap;
 
-  const CalendarScreen({
+  const CalendarGrid({
     super.key,
     required this.dateLayout,
     required this.selectedDates,
@@ -18,15 +18,16 @@ class CalendarScreen extends StatefulWidget {
   });
 
   @override
-  State<CalendarScreen> createState() => _CalendarScreenState();
+  State<CalendarGrid> createState() => _CalendarGridState();
 }
 
-class _CalendarScreenState extends State<CalendarScreen> {
+class _CalendarGridState extends State<CalendarGrid> {
   @override
   Widget build(BuildContext context) {
     final dateLayout = widget.dateLayout;
 
     return GridView.count(
+      physics: const NeverScrollableScrollPhysics(),
       shrinkWrap: true,
       crossAxisCount: 7,
       childAspectRatio: 1,

--- a/lib/ui/goal_calendar/goal_calendar_page.dart
+++ b/lib/ui/goal_calendar/goal_calendar_page.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_pager.dart';
+
+class GoalCalendarPage extends StatelessWidget {
+  final List<Goal> goals;
+
+  const GoalCalendarPage({super.key, required this.goals});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(child: GoalPager(goals: goals)),
+    );
+  }
+}

--- a/lib/ui/goal_calendar/goal_pager.dart
+++ b/lib/ui/goal_calendar/goal_pager.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/ui/goal_calendar/single_goal_calendar_view.dart';
+
+class GoalPager extends StatefulWidget {
+  final List<Goal> goals;
+
+  const GoalPager({super.key, required this.goals});
+
+  @override
+  State<GoalPager> createState() => _GoalPagerState();
+}
+
+class _GoalPagerState extends State<GoalPager> {
+  final PageController _controller = PageController();
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView.builder(
+        scrollDirection: Axis.vertical,
+        controller: _controller,
+        physics: const BouncingScrollPhysics(),
+        itemCount: widget.goals.length,
+        itemBuilder: (context, index) {
+          return AnimatedBuilder(
+            animation: _controller,
+            builder: (context, child) {
+              double value = _controller.hasClients && _controller.page != null
+                  ? (_controller.page! - index).clamp(-1, 1)
+                  : 0;
+              final scale = 1 - (value.abs() * 0.1);
+              return Transform.scale(
+                scale: scale,
+                child: Opacity(opacity: 1 - value.abs() * 0.3, child: child),
+              );
+            },
+            child: SingleGoalCalendarView(goal: widget.goals[index]),
+          );
+        });
+  }
+}

--- a/lib/ui/goal_calendar/header_section/calendar_header_section.dart
+++ b/lib/ui/goal_calendar/header_section/calendar_header_section.dart
@@ -11,12 +11,14 @@ class CalendarHeaderSection extends StatefulWidget {
   final Goal goal;
   final DateTime date;
   final ValueChanged<String> onGoalEditSubmitted;
+  final void Function(DateTime)? onMonthChanged;
 
   const CalendarHeaderSection({
     super.key,
     required this.goal,
     required this.date,
     required this.onGoalEditSubmitted,
+    this.onMonthChanged,
   });
 
   @override
@@ -26,6 +28,7 @@ class CalendarHeaderSection extends StatefulWidget {
 class _CalendarHeaderSectionState extends State<CalendarHeaderSection> {
   bool _isEditing = false;
   late final TextEditingController _controller;
+  late DateTime _currentMonth;
   final int maxLength = 20;
   final double buttonHeight = 48;
 
@@ -39,6 +42,7 @@ class _CalendarHeaderSectionState extends State<CalendarHeaderSection> {
   void initState() {
     super.initState();
     _controller = TextEditingController(text: widget.goal.title);
+    _currentMonth = widget.date;
   }
 
   @override
@@ -79,7 +83,15 @@ class _CalendarHeaderSectionState extends State<CalendarHeaderSection> {
                 },
               ),
         const SizedBox(height: 24),
-        MonthNavigationBar(referenceDate: widget.date),
+        MonthNavigationBar(
+          referenceDate: _currentMonth,
+          onMonthChanged: (newMonth) {
+            setState(() {
+              _currentMonth = newMonth;
+            });
+            widget.onMonthChanged?.call(newMonth);
+          },
+        ),
       ],
     );
   }

--- a/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
@@ -5,10 +5,12 @@ import 'package:haenaedda/provider/record_provider.dart';
 
 class MonthNavigationBar extends StatefulWidget {
   final DateTime referenceDate;
+  final void Function(DateTime)? onMonthChanged;
 
   const MonthNavigationBar({
     super.key,
     required this.referenceDate,
+    this.onMonthChanged,
   });
 
   @override
@@ -51,6 +53,7 @@ class _MonthNavigationBarState extends State<MonthNavigationBar> {
       setState(() {
         _focusedDate = DateTime(_focusedDate.year, _focusedDate.month - 1);
       });
+      widget.onMonthChanged?.call(_focusedDate);
     }
   }
 
@@ -59,6 +62,7 @@ class _MonthNavigationBarState extends State<MonthNavigationBar> {
       setState(() {
         _focusedDate = DateTime(_focusedDate.year, _focusedDate.month + 1);
       });
+      widget.onMonthChanged?.call(_focusedDate);
     }
   }
 

--- a/lib/ui/goal_calendar/my_calendar_page.dart
+++ b/lib/ui/goal_calendar/my_calendar_page.dart
@@ -5,7 +5,7 @@ import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/calendar_grid_layout.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/provider/record_provider.dart';
-import 'package:haenaedda/ui/goal_calendar/calendar_screen.dart';
+import 'package:haenaedda/ui/goal_calendar/calendar_grid.dart';
 import 'package:haenaedda/ui/goal_calendar/header_section/calendar_header_section.dart';
 import 'package:haenaedda/ui/widgets/section_divider.dart';
 
@@ -66,7 +66,7 @@ class _MyCalendarPageState extends State<MyCalendarPage> {
               }),
             ),
             const SizedBox(height: 24),
-            CalendarScreen(
+            CalendarGrid(
               dateLayout: dateLayout,
               selectedDates: selectedDates,
               onCellTap: (selectedDate) =>

--- a/lib/ui/goal_calendar/my_calendar_page.dart
+++ b/lib/ui/goal_calendar/my_calendar_page.dart
@@ -19,7 +19,7 @@ class MyCalendarPage extends StatefulWidget {
 }
 
 class _MyCalendarPageState extends State<MyCalendarPage> {
-  final DateTime _focusedDate = DateTime.now();
+  DateTime _focusedDate = DateTime.now();
 
   @override
   Widget build(BuildContext context) {
@@ -40,6 +40,11 @@ class _MyCalendarPageState extends State<MyCalendarPage> {
               date: _focusedDate,
               onGoalEditSubmitted: (String newGoal) {
                 recordProvider.renameGoal(widget.goal.id, newGoal);
+              },
+              onMonthChanged: (DateTime newMonth) {
+                setState(() {
+                  _focusedDate = newMonth;
+                });
               },
             ),
             const SizedBox(height: 24),

--- a/lib/ui/goal_calendar/my_calendar_page.dart
+++ b/lib/ui/goal_calendar/my_calendar_page.dart
@@ -28,49 +28,46 @@ class _MyCalendarPageState extends State<MyCalendarPage> {
     final dateLayout = CalendarGridLayout(_focusedDate);
     final daysOfWeek = AppLocalizations.of(context)!.shortWeekdays.split(',');
 
-    return Scaffold(
-      body: SafeArea(
-        child: SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-            child: Column(
-              children: [
-                const SizedBox(height: 30),
-                CalendarHeaderSection(
-                  goal: widget.goal,
-                  date: _focusedDate,
-                  onGoalEditSubmitted: (String newGoal) {
-                    recordProvider.renameGoal(widget.goal.id, newGoal);
-                  },
-                ),
-                const SizedBox(height: 24),
-                const SectionDivider(),
-                const SizedBox(height: 40),
-                Row(
-                  children: List.generate(daysOfWeek.length, (index) {
-                    return Expanded(
-                      child: Text(
-                        daysOfWeek[index],
-                        style: TextStyle(
-                          fontSize: 15,
-                          color: Theme.of(context).colorScheme.onSurface,
-                          fontWeight: FontWeight.bold,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    );
-                  }),
-                ),
-                const SizedBox(height: 24),
-                CalendarScreen(
-                  dateLayout: dateLayout,
-                  selectedDates: selectedDates,
-                  onCellTap: (selectedDate) =>
-                      recordProvider.toggleRecord(widget.goal.id, selectedDate),
-                ),
-              ],
+    return SingleChildScrollView(
+      physics: const NeverScrollableScrollPhysics(),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        child: Column(
+          children: [
+            const SizedBox(height: 30),
+            CalendarHeaderSection(
+              goal: widget.goal,
+              date: _focusedDate,
+              onGoalEditSubmitted: (String newGoal) {
+                recordProvider.renameGoal(widget.goal.id, newGoal);
+              },
             ),
-          ),
+            const SizedBox(height: 24),
+            const SectionDivider(),
+            const SizedBox(height: 40),
+            Row(
+              children: List.generate(daysOfWeek.length, (index) {
+                return Expanded(
+                  child: Text(
+                    daysOfWeek[index],
+                    style: TextStyle(
+                      fontSize: 15,
+                      color: Theme.of(context).colorScheme.onSurface,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                );
+              }),
+            ),
+            const SizedBox(height: 24),
+            CalendarScreen(
+              dateLayout: dateLayout,
+              selectedDates: selectedDates,
+              onCellTap: (selectedDate) =>
+                  recordProvider.toggleRecord(widget.goal.id, selectedDate),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/ui/goal_calendar/single_goal_calendar_view.dart
+++ b/lib/ui/goal_calendar/single_goal_calendar_view.dart
@@ -9,16 +9,16 @@ import 'package:haenaedda/ui/goal_calendar/calendar_grid.dart';
 import 'package:haenaedda/ui/goal_calendar/header_section/calendar_header_section.dart';
 import 'package:haenaedda/ui/widgets/section_divider.dart';
 
-class MyCalendarPage extends StatefulWidget {
+class SingleGoalCalendarView extends StatefulWidget {
   final Goal goal;
 
-  const MyCalendarPage({super.key, required this.goal});
+  const SingleGoalCalendarView({super.key, required this.goal});
 
   @override
-  State<MyCalendarPage> createState() => _MyCalendarPageState();
+  State<SingleGoalCalendarView> createState() => _SingleGoalCalendarViewState();
 }
 
-class _MyCalendarPageState extends State<MyCalendarPage> {
+class _SingleGoalCalendarViewState extends State<SingleGoalCalendarView> {
   DateTime _focusedDate = DateTime.now();
 
   @override


### PR DESCRIPTION
## 변경 목적
- 여러 개의 목표(goal)를 전환하면서 확인할 수 있도록 목표 간 수직 스와이프 기능을 추가했습니다.

## 주요 변경 사항
- GoalCalendarPage
    - 전체 goal 리스트를 받아 GoalPager에 전달
- GoalPager
    - 각 goal마다 SingleGoalCalendarView를 하나씩 생성하고, PageView로 수직 전환
- PageView에 애니메이션 효과 추가
    - 현재 페이지에서 멀어질수록 작아보이게 
      > 페이지 중심에서 벗어날수록 10%까지 축소 
      > `scale = 1 - (value.abs() * 0.1)`
    - 현재 페이지에서 멀어질수록 투명해지게 
      > 페이지 중심에서 벗어날수록 opacity가 0.7까지 감소  
      > `opacity: 1 - value.abs() * 0.3`

- initializeAndGetGoals() 메서드 수정
    - goal 하나에서 goal 리스트를 받도록 수정 
- loadGoals(), loadRecords() 오류 처리 개선
    - 비어 있을 경우 내부 상태 초기화 / 로딩 실패 구분 처리
- `List<dynamic>` → `List<Goal>` 변환 오류 수정 -> Goal json 파싱 시 타입 캐스팅 추가
- 목표 이름 변경 후 saveGoals() 누락되어 있던 문제 수정

## 기대 효과
- 사용자가 등록한 여러 목표를 스와이프로 전환하면서 달력을 확인할 수 있음
- 이후 목표 추가 기능과 연동 시, UX 흐름이 자연스러워질 기반 마련

## 다음 계획
- 목표 추가
- 목표 삭제 및 순서 변경 