### PR TITLE
Feature: 목표 추가 플로우 구현

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "haenaedda",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "haenaedda (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "haenaedda (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,11 @@ void main() {
   runApp(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => RecordProvider()),
+        ChangeNotifierProvider(create: (_) {
+          final recordProvider = RecordProvider();
+          recordProvider.loadGoals();
+          return recordProvider;
+        }),
       ],
       child: const Haenaedda(),
     ),

--- a/lib/model/goal_setting_action.dart
+++ b/lib/model/goal_setting_action.dart
@@ -1,0 +1,5 @@
+enum GoalSettingAction {
+  addGoal,
+  resetRecordsOnly,
+  resetEntireGoal,
+}

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -39,6 +39,7 @@ class RecordProvider extends ChangeNotifier {
   final Map<String, DateRecordSet> _recordsByGoalId = {};
   static const String _firstGoalId = '10';
   static const int _orderStep = 10;
+  bool _isLoaded = false;
 
   Map<String, DateRecordSet> get recordsByGoal => _recordsByGoalId;
 
@@ -51,6 +52,8 @@ class RecordProvider extends ChangeNotifier {
     if (_goals.isEmpty) return null;
     return _goals.firstWhereOrNull((g) => g.id == _firstGoalId);
   }
+
+  bool get isLoaded => _isLoaded;
 
   bool isGoalsEmpty() => _goals.isEmpty;
 
@@ -175,6 +178,7 @@ class RecordProvider extends ChangeNotifier {
       if (loadedGoalsJson == null) {
         _clearGoals();
         debugPrint('No saved goals found. Clearing internal goal state.');
+        _isLoaded = true;
         return true;
       }
 
@@ -182,8 +186,11 @@ class RecordProvider extends ChangeNotifier {
       final List<Goal> restoredGoals = (decodedGoalsJson as List)
           .map((e) => Goal.fromJson((e as Map<String, dynamic>)))
           .toList();
-      _goals = restoredGoals;
+      _goals
+        ..clear()
+        ..addAll(restoredGoals);
       _syncSortedGoals();
+      _isLoaded = true;
       notifyListeners();
       return true;
     } catch (e) {

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -133,18 +133,19 @@ class RecordProvider extends ChangeNotifier {
   }
 
   Future<RenameGoalResult> renameGoal(
-      String goalId, String newGoalTitle) async {
-    if (newGoalTitle.trim().isEmpty) {
+      Goal selectedGoal, String newTitle) async {
+    if (newTitle.trim().isEmpty) {
       return RenameGoalResult.emptyInput;
     }
-    if (isDuplicateGoal(newGoalTitle)) {
+    if (isDuplicateGoal(newTitle)) {
       return RenameGoalResult.duplicate;
     }
-    final goal = _goals.firstWhereOrNull((goal) => goal.id == goalId);
-    if (goal == null) {
+    final newGoal =
+        _goals.firstWhereOrNull((goal) => goal.id == selectedGoal.id);
+    if (newGoal == null) {
       return RenameGoalResult.notFound;
     }
-    goal.title = newGoalTitle;
+    newGoal.title = newTitle;
     saveGoals();
     notifyListeners();
     return RenameGoalResult.success;

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -133,7 +133,9 @@ class RecordProvider extends ChangeNotifier {
   }
 
   Future<RenameGoalResult> renameGoal(
-      Goal selectedGoal, String newTitle) async {
+    Goal selectedGoal,
+    String newTitle,
+  ) async {
     if (newTitle.trim().isEmpty) {
       return RenameGoalResult.emptyInput;
     }

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -281,6 +281,7 @@ class RecordProvider extends ChangeNotifier {
         final updatedGoalsJson =
             jsonEncode(_goals.map((g) => g.toJson()).toList());
         final saved = await prefs.setString('goals', updatedGoalsJson);
+        _syncSortedGoals();
         notifyListeners();
         return saved;
       }

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -311,4 +311,25 @@ class RecordProvider extends ChangeNotifier {
       await saveGoals();
     }
   }
+
+// 📌 Scroll Focus Management for Newly Added Goal
+// Used to scroll to the newly added goal once, immediately after creation.
+// Cleared in GoalPager after being consumed.
+
+  Goal? _focusedGoalForScroll;
+  bool _shouldScrollToFocusedPage = false;
+
+  Goal? get focusedGoalForScroll => _focusedGoalForScroll;
+  bool get shouldScrollToFocusedPage => _shouldScrollToFocusedPage;
+
+  void setFocusedGoalForScroll(Goal goal) {
+    _focusedGoalForScroll = goal;
+    _shouldScrollToFocusedPage = true;
+    notifyListeners();
+  }
+
+  void clearFocusedGoalForScroll() {
+    _focusedGoalForScroll = null;
+    _shouldScrollToFocusedPage = false;
+  }
 }

--- a/lib/theme/buttons.dart
+++ b/lib/theme/buttons.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+ButtonStyle getButtonStyle({
+  required Color background,
+  required Color foreground,
+}) {
+  return ButtonStyle(
+    padding: WidgetStateProperty.all(
+      const EdgeInsets.symmetric(vertical: 14),
+    ),
+    backgroundColor: WidgetStateProperty.all(background),
+    foregroundColor: WidgetStateProperty.all(foreground),
+    overlayColor: WidgetStateProperty.resolveWith((states) {
+      if (states.contains(WidgetState.pressed)) {
+        return Colors.black.withValues(alpha: 0.04);
+      }
+      return null;
+    }),
+    shape: WidgetStateProperty.all(
+      RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+    ),
+    splashFactory: NoSplash.splashFactory,
+  );
+}
+
+TextStyle getButtonTextStyle({
+  Color? color,
+  double fontSize = 16,
+  FontWeight fontWeight = FontWeight.bold,
+}) {
+  return TextStyle(fontSize: fontSize, fontWeight: fontWeight, color: color);
+}

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -26,13 +26,6 @@ class _EditGoalPageState extends State<EditGoalPage> {
     super.dispose();
   }
 
-  void _onSave() {
-    final trimmed = _controller.text.trim();
-    if (trimmed.isNotEmpty) {
-      Navigator.of(context).pop(trimmed);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -56,7 +49,12 @@ class _EditGoalPageState extends State<EditGoalPage> {
             ),
             actions: [
               TextButton(
-                onPressed: _onSave,
+                onPressed: () {
+                  final trimmed = _controller.text.trim();
+                  if (trimmed.isNotEmpty) {
+                    Navigator.of(context).pop(trimmed);
+                  }
+                },
                 child: Text(
                   AppLocalizations.of(context)!.add,
                   style: TextStyle(

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:haenaedda/gen_l10n/app_localizations.dart';
+import 'package:haenaedda/ui/settings/handlers/edit_goal_handler.dart';
+
+class EditGoalPage extends StatefulWidget {
+  final String? initialText;
+
+  const EditGoalPage({super.key, this.initialText});
+
+  @override
+  State<EditGoalPage> createState() => _EditGoalPageState();
+}
+
+class _EditGoalPageState extends State<EditGoalPage> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialText ?? '');
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _onSave() {
+    final trimmed = _controller.text.trim();
+    if (trimmed.isNotEmpty) {
+      Navigator.of(context).pop(trimmed);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        await _handlePop(context);
+      },
+      child: GestureDetector(
+        onTap: () => FocusScope.of(context).unfocus(),
+        behavior: HitTestBehavior.opaque,
+        child: Scaffold(
+          backgroundColor: colorScheme.surface,
+          appBar: AppBar(
+            backgroundColor: colorScheme.surface,
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () => _handlePop(context),
+            ),
+            actions: [
+              TextButton(
+                onPressed: _onSave,
+                child: Text(
+                  AppLocalizations.of(context)!.add,
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+            elevation: 0,
+          ),
+          body: LayoutBuilder(
+            builder: (context, constraints) {
+              return SingleChildScrollView(
+                padding: EdgeInsets.only(
+                  top: constraints.maxHeight * 0.25,
+                  bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+                ),
+                child: Center(
+                  child: Column(
+                    children: [
+                      Text(
+                        AppLocalizations.of(context)!.editGoalPrompt,
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: colorScheme.onSurface.withValues(alpha: 0.4),
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 24),
+                        child: TextField(
+                          controller: _controller,
+                          maxLines: 2,
+                          maxLength: 40,
+                          autofocus: true,
+                          style: TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.w700,
+                            color: colorScheme.onSurface,
+                          ),
+                          decoration: const InputDecoration(
+                            border: InputBorder.none,
+                            contentPadding: EdgeInsets.zero,
+                            counterText: '',
+                          ),
+                          cursorColor: colorScheme.onSurface,
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handlePop(BuildContext context) async {
+    final original = widget.initialText?.trim() ?? '';
+    final current = _controller.text.trim();
+    final isDirty = current.isNotEmpty && current != original;
+
+    if (!isDirty) {
+      if (context.mounted) Navigator.of(context).pop();
+      return;
+    }
+
+    final confirmed = await confirmDiscardChanges(context);
+    if (context.mounted && confirmed == true) {
+      Navigator.of(context).pop();
+    }
+  }
+}

--- a/lib/ui/goal_calendar/goal_pager.dart
+++ b/lib/ui/goal_calendar/goal_pager.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/single_goal_calendar_view.dart';
 
 class GoalPager extends StatefulWidget {
@@ -12,30 +15,58 @@ class GoalPager extends StatefulWidget {
 }
 
 class _GoalPagerState extends State<GoalPager> {
-  final PageController _controller = PageController();
+  late final PageController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PageController();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final provider = context.read<RecordProvider>();
+      final focusedGoal = provider.focusedGoalForScroll;
+      if (focusedGoal != null) {
+        final index = widget.goals.indexWhere((g) => g.id == focusedGoal.id);
+        if (index != -1) {
+          _controller.jumpToPage(index);
+        }
+        provider.clearFocusedGoalForScroll();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
-        scrollDirection: Axis.vertical,
-        controller: _controller,
-        physics: const BouncingScrollPhysics(),
-        itemCount: widget.goals.length,
-        itemBuilder: (context, index) {
-          return AnimatedBuilder(
-            animation: _controller,
-            builder: (context, child) {
-              double value = _controller.hasClients && _controller.page != null
-                  ? (_controller.page! - index).clamp(-1, 1)
-                  : 0;
-              final scale = 1 - (value.abs() * 0.1);
-              return Transform.scale(
-                scale: scale,
-                child: Opacity(opacity: 1 - value.abs() * 0.3, child: child),
-              );
-            },
-            child: SingleGoalCalendarView(goal: widget.goals[index]),
-          );
-        });
+      scrollDirection: Axis.vertical,
+      controller: _controller,
+      physics: const BouncingScrollPhysics(),
+      itemCount: widget.goals.length,
+      itemBuilder: (context, index) {
+        return AnimatedBuilder(
+          animation: _controller,
+          builder: (context, child) {
+            if (!_controller.hasClients || _controller.page == null) {
+              return child!;
+            }
+            final value = (_controller.page! - index).clamp(-1.0, 1.0);
+            final scale = 1 - (value.abs() * 0.1);
+            return Transform.scale(
+              scale: scale,
+              child: Opacity(opacity: 1 - value.abs() * 0.3, child: child),
+            );
+          },
+          child: SingleGoalCalendarView(
+            key: ValueKey(widget.goals[index].id),
+            goal: widget.goals[index],
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/ui/goal_calendar/header_section/goal_display_text.dart
+++ b/lib/ui/goal_calendar/header_section/goal_display_text.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:haenaedda/model/goal.dart';
+import 'package:provider/provider.dart';
 
-import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
+import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 import 'package:haenaedda/ui/settings/settings_button.dart';
 
 class GoalDisplayText extends StatelessWidget {
@@ -23,6 +25,9 @@ class GoalDisplayText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final updatedGoal = context.select<RecordProvider, Goal>(
+      (provider) => provider.getGoalById(goal.id) ?? goal,
+    );
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
@@ -34,11 +39,11 @@ class GoalDisplayText extends StatelessWidget {
             decoration: NeumorphicTheme.pressedBoxDecoration(context),
             alignment: Alignment.centerLeft,
             child: Text(
-              controller.text.isEmpty
+              updatedGoal.title.isEmpty
                   ? AppLocalizations.of(context)!.goalSetupHint
-                  : controller.text,
+                  : updatedGoal.title,
               style: goalTextStyle.copyWith(
-                color: controller.text.isEmpty
+                color: updatedGoal.title.isEmpty
                     ? Theme.of(context).colorScheme.outline
                     : null,
               ),

--- a/lib/ui/goal_calendar/header_section/goal_edit_field.dart
+++ b/lib/ui/goal_calendar/header_section/goal_edit_field.dart
@@ -4,15 +4,15 @@ import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 class GoalEditField extends StatefulWidget {
   final double buttonHeight;
   final TextStyle goalTextStyle;
-  final VoidCallback onSave;
-  final TextEditingController controller;
+  final ValueChanged<String> onSave;
+  final String initialText;
 
   const GoalEditField({
     super.key,
     required this.buttonHeight,
     required this.goalTextStyle,
     required this.onSave,
-    required this.controller,
+    required this.initialText,
   });
 
   @override
@@ -20,6 +20,20 @@ class GoalEditField extends StatefulWidget {
 }
 
 class _GoalEditFieldState extends State<GoalEditField> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialText);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -31,7 +45,7 @@ class _GoalEditFieldState extends State<GoalEditField> {
             decoration: NeumorphicTheme.pressedBoxDecoration(context),
             alignment: Alignment.centerLeft,
             child: TextField(
-              controller: widget.controller,
+              controller: _controller,
               style: widget.goalTextStyle,
               autofocus: true,
               decoration: const InputDecoration(
@@ -44,7 +58,7 @@ class _GoalEditFieldState extends State<GoalEditField> {
         ),
         const SizedBox(width: 8),
         GestureDetector(
-          onTap: widget.onSave,
+          onTap: () => widget.onSave(_controller.text),
           child: Container(
             height: widget.buttonHeight,
             width: widget.buttonHeight,

--- a/lib/ui/goal_calendar/single_goal_calendar_view.dart
+++ b/lib/ui/goal_calendar/single_goal_calendar_view.dart
@@ -38,8 +38,8 @@ class _SingleGoalCalendarViewState extends State<SingleGoalCalendarView> {
             CalendarHeaderSection(
               goal: widget.goal,
               date: _focusedDate,
-              onGoalEditSubmitted: (String newGoal) {
-                recordProvider.renameGoal(widget.goal.id, newGoal);
+              onGoalEditSubmitted: (String newTitle) {
+                recordProvider.renameGoal(widget.goal, newTitle);
               },
               onMonthChanged: (DateTime newMonth) {
                 setState(() {

--- a/lib/ui/goal_calendar/single_goal_calendar_view.dart
+++ b/lib/ui/goal_calendar/single_goal_calendar_view.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/calendar_grid_layout.dart';
+import 'package:haenaedda/model/date_record_set.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/calendar_grid.dart';
@@ -22,11 +23,21 @@ class _SingleGoalCalendarViewState extends State<SingleGoalCalendarView> {
   DateTime _focusedDate = DateTime.now();
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final recordProvider = context.watch<RecordProvider>();
-    final selectedDates = recordProvider.getRecords(widget.goal.id);
     final dateLayout = CalendarGridLayout(_focusedDate);
     final daysOfWeek = AppLocalizations.of(context)!.shortWeekdays.split(',');
+    final goal = context.select<RecordProvider, Goal?>(
+      (provider) => provider.getGoalById(widget.goal.id),
+    );
+    if (goal == null) return const SizedBox.shrink();
 
     return SingleChildScrollView(
       physics: const NeverScrollableScrollPhysics(),
@@ -36,15 +47,12 @@ class _SingleGoalCalendarViewState extends State<SingleGoalCalendarView> {
           children: [
             const SizedBox(height: 30),
             CalendarHeaderSection(
-              goal: widget.goal,
+              goal: goal,
               date: _focusedDate,
-              onGoalEditSubmitted: (String newTitle) {
-                recordProvider.renameGoal(widget.goal, newTitle);
-              },
+              onGoalEditSubmitted: (String newTitle) =>
+                  context.read<RecordProvider>().renameGoal(goal, newTitle),
               onMonthChanged: (DateTime newMonth) {
-                setState(() {
-                  _focusedDate = newMonth;
-                });
+                setState(() => _focusedDate = newMonth);
               },
             ),
             const SizedBox(height: 24),
@@ -66,12 +74,15 @@ class _SingleGoalCalendarViewState extends State<SingleGoalCalendarView> {
               }),
             ),
             const SizedBox(height: 24),
-            CalendarGrid(
-              dateLayout: dateLayout,
-              selectedDates: selectedDates,
-              onCellTap: (selectedDate) =>
-                  recordProvider.toggleRecord(widget.goal.id, selectedDate),
-            ),
+            Selector<RecordProvider, DateRecordSet>(
+                selector: (_, provider) => provider.getRecords(goal.id),
+                builder: (_, selectedDates, __) => CalendarGrid(
+                      dateLayout: dateLayout,
+                      selectedDates: selectedDates,
+                      onCellTap: (selectedDate) => context
+                          .read<RecordProvider>()
+                          .toggleRecord(goal.id, selectedDate),
+                    )),
           ],
         ),
       ),

--- a/lib/ui/settings/handlers/edit_goal_handler.dart
+++ b/lib/ui/settings/handlers/edit_goal_handler.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
+
+Future<void> onAddGoalPressed(BuildContext context) async {
+  final recordProvider = context.read<RecordProvider>();
+  final inputText = await Navigator.push<String>(
+    context,
+    MaterialPageRoute(builder: (_) => const EditGoalPage()),
+  );
+
+  if (!context.mounted || inputText == null) return;
+  final (result: addResult, goal: newGoal) =
+      await recordProvider.addGoal(inputText);
+  switch (addResult) {
+    case AddGoalResult.emptyInput:
+      break;
+    case AddGoalResult.duplicate:
+      break;
+    case AddGoalResult.saveFailed:
+      break;
+    case AddGoalResult.success:
+      if (newGoal != null) {
+        recordProvider.setFocusedGoalForScroll(newGoal);
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => const GoalCalendarPage()),
+        );
+      } else {
+        debugPrint('⚠️ Failed to add newGoal: newGoal is null');
+      }
+      break;
+  }
+}

--- a/lib/ui/settings/handlers/edit_goal_handler.dart
+++ b/lib/ui/settings/handlers/edit_goal_handler.dart
@@ -1,9 +1,111 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/theme/buttons.dart';
 import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
+
+Future<void> onDiscardDuringInput(
+    BuildContext context, TextEditingController controller) async {
+  final trimmedText = controller.text.trim();
+  if (trimmedText.isEmpty) {
+    Navigator.of(context).pop();
+    return;
+  }
+  final discardConfirmed = await confirmDiscardChanges(context);
+  if (!context.mounted) return;
+  if (discardConfirmed == true) {
+    controller.clear();
+    Navigator.of(context).pop();
+  }
+}
+
+Future<bool?> confirmDiscardChanges(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+  final l10n = AppLocalizations.of(context)!;
+
+  return showGeneralDialog(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel: l10n.dismiss,
+    barrierColor: Colors.black.withValues(alpha: 0.2),
+    transitionDuration: const Duration(milliseconds: 300),
+    pageBuilder: (context, _, __) => Material(
+      color: Colors.transparent,
+      child: Center(
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 24),
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(24),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.08),
+                blurRadius: 20,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                l10n.unsavedChanges,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                l10n.unsavedChangesMessage,
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 14, color: Colors.grey.shade700),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: TextButton(
+                        style: getButtonStyle(
+                          background: colorScheme.outline,
+                          foreground: colorScheme.onSurfaceVariant,
+                        ),
+                        onPressed: () => Navigator.of(context).pop(true),
+                        child: Text(l10n.leave, style: getButtonTextStyle()),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: TextButton(
+                        style: getButtonStyle(
+                          background: colorScheme.onError,
+                          foreground: colorScheme.error,
+                        ),
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child:
+                            Text(l10n.keepEditing, style: getButtonTextStyle()),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
 
 Future<void> onAddGoalPressed(BuildContext context) async {
   final recordProvider = context.read<RecordProvider>();

--- a/lib/ui/settings/handlers/reset_goal_handler.dart
+++ b/lib/ui/settings/handlers/reset_goal_handler.dart
@@ -5,6 +5,7 @@ import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/model/reset_type.dart';
 import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
 
 Future<void> showResetFailureDialog(BuildContext context, ResetType type) {
   final l10n = AppLocalizations.of(context)!;
@@ -114,8 +115,10 @@ Future<void> _handleEntireGoalReset(BuildContext context, Goal goal) async {
 
   switch (result) {
     case ResetEntireGoalResult.success:
-      await provider.ensureAtLeastOneGoalExists();
-      if (context.mounted) Navigator.of(context).pop();
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const GoalCalendarPage()),
+      );
       break;
     case ResetEntireGoalResult.recordFailed:
       await showResetFailureDialog(context, ResetType.recordsOnly);

--- a/lib/ui/settings/settings_bottom_modal.dart
+++ b/lib/ui/settings/settings_bottom_modal.dart
@@ -4,6 +4,7 @@ import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/model/goal_setting_action.dart';
 import 'package:haenaedda/model/reset_type.dart';
+import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
 import 'package:haenaedda/ui/settings/handlers/reset_goal_handler.dart';
 import 'package:haenaedda/ui/settings/neumorphic_settings_tile.dart';
 import 'package:haenaedda/ui/widgets/modal_action_icon_buttons.dart';

--- a/lib/ui/settings/settings_bottom_modal.dart
+++ b/lib/ui/settings/settings_bottom_modal.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/model/goal_setting_action.dart';
 import 'package:haenaedda/model/reset_type.dart';
+import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
 import 'package:haenaedda/ui/settings/handlers/reset_goal_handler.dart';
 import 'package:haenaedda/ui/settings/neumorphic_settings_tile.dart';

--- a/lib/ui/settings/settings_bottom_modal.dart
+++ b/lib/ui/settings/settings_bottom_modal.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/model/goal_setting_action.dart';
 import 'package:haenaedda/model/reset_type.dart';
 import 'package:haenaedda/ui/settings/handlers/reset_goal_handler.dart';
 import 'package:haenaedda/ui/settings/neumorphic_settings_tile.dart';
@@ -70,7 +71,13 @@ class _SettingsBottomModalState extends State<SettingsBottomModal> {
                     ),
                   ),
                   const SectionDivider(),
-                  const SizedBox(height: 8.0),
+                  const SizedBox(height: 12.0),
+                  NeumorphicSettingsTile(
+                    title: AppLocalizations.of(context)!.addGoal,
+                    onTap: () =>
+                        Navigator.of(context).pop(GoalSettingAction.addGoal),
+                  ),
+                  const SizedBox(height: 16.0),
                   NeumorphicSettingsTile(
                     title: AppLocalizations.of(context)!.resetRecordsOnly,
                     onTap: () => onResetButtonTap(

--- a/lib/ui/settings/settings_button.dart
+++ b/lib/ui/settings/settings_button.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
+import 'package:haenaedda/model/goal_setting_action.dart';
+import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/ui/settings/handlers/edit_goal_handler.dart';
 import 'package:haenaedda/ui/settings/settings_bottom_modal.dart';
 
 class SettingButton extends StatelessWidget {
@@ -11,8 +16,9 @@ class SettingButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      onPressed: () {
-        showGeneralDialog(
+      onPressed: () async {
+        final recordProvider = context.read<RecordProvider>();
+        final action = await showGeneralDialog<GoalSettingAction?>(
           context: context,
           barrierDismissible: true,
           barrierLabel: AppLocalizations.of(context)!.dismiss,
@@ -29,6 +35,16 @@ class SettingButton extends StatelessWidget {
             return SlideTransition(position: offset, child: child);
           },
         );
+        if (!context.mounted) return;
+        switch (action) {
+          case GoalSettingAction.addGoal:
+            await onAddGoalPressed(context);
+          case GoalSettingAction.resetRecordsOnly:
+            recordProvider.removeRecordsOnly(goal.id);
+          case GoalSettingAction.resetEntireGoal:
+            recordProvider.resetEntireGoal(goal.id);
+          case null:
+        }
       },
       icon: const Icon(Icons.settings),
       splashColor: Colors.transparent,


### PR DESCRIPTION
🔧 변경 목적
- 사용자가 새로운 목표를 추가할 수 있도록 기능을 구현했습니다. 
- 이 과정에서 발견한 기존의 에러를 함께 수정했습니다.

🛠 주요 변경 사항
- 목표 추가/수정 페이지 및 로직 도입 (EditGoalPage)
- 목표 추가 결과를 AddGoalResult enum으로 명시적으로 처리
- goal 저장 실패 시 대응 로직 및 에러 방어 처리 추가
- 목표 추가 시 중복/빈 값 등 예외 처리 추가

## 기대 효과
- 목표 추가가 가능해짐
- 이후 브랜치(refactor/internal-goal-logic, ui/style-and-i18n)의 기반이 되는 핵심 기능 마련
- 상태 처리와 예외 처리에 기반한 안정적인 사용자 경험 제공

## 다음 계획
- 목표 삭제 및 수정 기능 개선