### PR TITLE
Fix: 런처 페이지 도입 및 초기 Goal 추가 플로우 안정화

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -110,14 +110,23 @@
         "description": "Button label to leave the screen without saving or completing input",
         "type": "text"
     },
-    "editGoalPrompt": "What do you want to achieve this time?",
-    "@editGoalPrompt": {
+    "addGoalPrompt": "What do you want to achieve this time?",
+    "@addGoalPrompt": {
         "description": "A prompt shown when the user is asked to enter a new or edited goal",
         "type": "text"
     },
     "editCurrentGoal": "Edit goal name",
     "@editCurrentGoal": {
         "description": "Settings menu item for editing the current goal's title",
+        "type": "text"
+    },
+    "save": "Save",
+    "@save": {
+        "description": "Label for the save button when editing an existing goal"
+    },
+    "editGoalPrompt": "How about tweaking your goal a bit?",
+    "@editGoalPrompt": {
+        "description": "A prompt shown when the user is editing an existing goal",
         "type": "text"
     }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -110,14 +110,23 @@
         "description": "Button label to leave the screen without saving or completing input",
         "type": "text"
     },
-    "editGoalPrompt": "이번에 해내고 싶은 건 뭔가요?",
-    "@editGoalPrompt": {
+    "addGoalPrompt": "이번에 해내고 싶은 건 뭔가요?",
+    "@addGoalPrompt": {
         "description": "A prompt shown when the user is asked to enter a new or edited goal",
         "type": "text"
     },
     "editCurrentGoal": "현재 목표 수정",
     "@editCurrentGoal": {
         "description": "Settings menu item for editing the current goal's title",
+        "type": "text"
+    },
+    "save": "저장",
+    "@save": {
+        "description": "Label for the save button when editing an existing goal"
+    },
+    "editGoalPrompt": "목표를 조금 다듬어볼까요?",
+    "@editGoalPrompt": {
+        "description": "A prompt shown when the user is editing an existing goal",
         "type": "text"
     }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/app_theme.dart';
-import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
+import 'package:haenaedda/ui/launcher/launcher_page.dart';
 
 void main() {
   runApp(
@@ -54,7 +54,7 @@ class _HaenaeddaState extends State<Haenaedda> {
         Locale('en'),
         Locale('ko'),
       ],
-      home: const GoalCalendarPage(),
+      home: const LauncherPage(),
     );
   }
 }

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -18,12 +18,21 @@ class _EditGoalPageState extends State<EditGoalPage> {
   final TextEditingController _controller = TextEditingController();
   final FocusNode _focusNode = FocusNode();
   bool _isDiscardCheckInProgress = false;
+  bool _isButtonEnabled = false;
 
   @override
   void initState() {
     super.initState();
     _controller.text = widget.initialText ?? '';
-    _controller.addListener(() => setState(() {}));
+    _isButtonEnabled = _controller.text.trim().isNotEmpty &&
+        _controller.text.trim() != (widget.initialText ?? '').trim();
+    _controller.addListener(() {
+      final trimmed = _controller.text.trim();
+      setState(() {
+        _isButtonEnabled =
+            trimmed.isNotEmpty && trimmed != (widget.initialText ?? '').trim();
+      });
+    });
   }
 
   @override
@@ -69,15 +78,12 @@ class _EditGoalPageState extends State<EditGoalPage> {
             ),
             actions: [
               TextButton(
-                onPressed: _controller.text.isEmpty
-                    ? null
-                    : () {
-                        final trimmed = _controller.text.trim();
-                        if (trimmed.isNotEmpty) {
-                          Navigator.of(context)
-                              .pop(GoalEditResult(title: trimmed, isNew: true));
-                        }
-                      },
+                onPressed: _isButtonEnabled
+                    ? () {
+                        Navigator.of(context).pop(GoalEditResult(
+                            title: _controller.text, isNew: true));
+                      }
+                    : null,
                 style: ButtonStyle(
                   splashFactory: NoSplash.splashFactory,
                   overlayColor: WidgetStateProperty.all(Colors.transparent),
@@ -88,9 +94,9 @@ class _EditGoalPageState extends State<EditGoalPage> {
                   AppLocalizations.of(context)!.add,
                   style: TextStyle(
                     fontSize: 18,
-                    color: _controller.text.isEmpty
-                        ? colorScheme.outline
-                        : colorScheme.onSurface,
+                    color: _isButtonEnabled
+                        ? colorScheme.onSurface
+                        : colorScheme.outline,
                     fontWeight: FontWeight.w600,
                   ),
                 ),
@@ -140,6 +146,11 @@ class _EditGoalPageState extends State<EditGoalPage> {
                           keyboardType: TextInputType.text,
                           onSubmitted: (_) => FocusScope.of(context).unfocus(),
                           focusNode: _focusNode,
+                          onChanged: (value) {
+                            setState(() {
+                              _isButtonEnabled = value.trim().isNotEmpty;
+                            });
+                          },
                         ),
                       ),
                     ],

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
 import 'package:haenaedda/ui/settings/handlers/edit_goal_handler.dart';
 import 'package:provider/provider.dart';
 
@@ -73,7 +74,8 @@ class _EditGoalPageState extends State<EditGoalPage> {
                     : () {
                         final trimmed = _controller.text.trim();
                         if (trimmed.isNotEmpty) {
-                          Navigator.of(context).pop(trimmed);
+                          Navigator.of(context)
+                              .pop(GoalEditResult(title: trimmed, isNew: true));
                         }
                       },
                 style: ButtonStyle(

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -39,6 +39,9 @@ class _EditGoalPageState extends State<EditGoalPage> {
             trimmed.isNotEmpty && trimmed != (widget.initialText ?? '').trim();
       });
     });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _focusNode.requestFocus();
+    });
   }
 
   @override
@@ -140,7 +143,6 @@ class _EditGoalPageState extends State<EditGoalPage> {
                           controller: _controller,
                           maxLines: 2,
                           maxLength: 40,
-                          autofocus: true,
                           style: TextStyle(
                             fontSize: 20,
                             fontWeight: FontWeight.w700,

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -1,14 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
 import 'package:haenaedda/ui/settings/handlers/edit_goal_handler.dart';
-import 'package:provider/provider.dart';
 
 class EditGoalPage extends StatefulWidget {
   final String? initialText;
+  final GoalEditMode mode;
 
-  const EditGoalPage({super.key, this.initialText});
+  const EditGoalPage({
+    super.key,
+    this.initialText,
+    this.mode = GoalEditMode.create,
+  });
 
   @override
   State<EditGoalPage> createState() => _EditGoalPageState();
@@ -45,6 +51,7 @@ class _EditGoalPageState extends State<EditGoalPage> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context)!;
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) async {
@@ -81,7 +88,9 @@ class _EditGoalPageState extends State<EditGoalPage> {
                 onPressed: _isButtonEnabled
                     ? () {
                         Navigator.of(context).pop(GoalEditResult(
-                            title: _controller.text, isNew: true));
+                          title: _controller.text.trim(),
+                          mode: widget.mode,
+                        ));
                       }
                     : null,
                 style: ButtonStyle(
@@ -91,7 +100,7 @@ class _EditGoalPageState extends State<EditGoalPage> {
                       WidgetStateProperty.all(colorScheme.onSurface),
                 ),
                 child: Text(
-                  AppLocalizations.of(context)!.add,
+                  widget.mode == GoalEditMode.create ? l10n.add : l10n.save,
                   style: TextStyle(
                     fontSize: 18,
                     color: _isButtonEnabled
@@ -115,7 +124,9 @@ class _EditGoalPageState extends State<EditGoalPage> {
                   child: Column(
                     children: [
                       Text(
-                        AppLocalizations.of(context)!.editGoalPrompt,
+                        widget.mode == GoalEditMode.create
+                            ? l10n.addGoalPrompt
+                            : l10n.editGoalPrompt,
                         style: TextStyle(
                           fontSize: 16,
                           color: colorScheme.onSurface.withValues(alpha: 0.4),
@@ -148,7 +159,13 @@ class _EditGoalPageState extends State<EditGoalPage> {
                           focusNode: _focusNode,
                           onChanged: (value) {
                             setState(() {
-                              _isButtonEnabled = value.trim().isNotEmpty;
+                              final trimmed = value.trim();
+                              final original =
+                                  (widget.initialText ?? '').trim();
+                              setState(() {
+                                _isButtonEnabled =
+                                    trimmed.isNotEmpty && trimmed != original;
+                              });
                             });
                           },
                         ),

--- a/lib/ui/goal_calendar/goal_calendar_page.dart
+++ b/lib/ui/goal_calendar/goal_calendar_page.dart
@@ -16,51 +16,24 @@ class GoalCalendarPage extends StatefulWidget {
 
 class _GoalCalendarPageState extends State<GoalCalendarPage> {
   final PageController _pageController = PageController();
-  bool _hasRedirected = false;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final provider = context.read<RecordProvider>();
-      if (provider.isLoaded && provider.hasNoGoal) {
-        _navigateToAddGoalPage();
+      final isLoaded = provider.isLoaded;
+      final goals = provider.sortedGoals;
+      if (isLoaded && goals.isEmpty) {
+        _showEditGoalDialog();
       }
     });
   }
 
-  Future<void> _navigateToAddGoalPage() async {
-    final result = await Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => const EditGoalPage()),
-    );
-    if (mounted && result is String && result.trim().isNotEmpty) {
-      final provider = context.read<RecordProvider>();
-      final (result: addResult, goal: newGoal) = await provider.addGoal(result);
-      if (newGoal != null) provider.setFocusedGoalForScroll(newGoal);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final isLoaded =
-        context.select<RecordProvider, bool>((provider) => provider.isLoaded);
-    final goals = context
-        .select<RecordProvider, List<Goal>>((provider) => provider.sortedGoals);
-
-    if (!isLoaded) return _buildLoadingIndicator();
-    if (goals.isEmpty && !_hasRedirected) {
-      _hasRedirected = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (context.mounted && goals.isEmpty) {
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(builder: (_) => const EditGoalPage()),
-          );
-        }
-      });
-    }
-    if (goals.isEmpty) return _buildLoadingIndicator();
+    final goals =
+        context.select<RecordProvider, List<Goal>>((p) => p.sortedGoals);
     return Scaffold(
       body: SafeArea(
         child: GoalPager(goals: goals, controller: _pageController),
@@ -68,13 +41,20 @@ class _GoalCalendarPageState extends State<GoalCalendarPage> {
     );
   }
 
-  Widget _buildLoadingIndicator() {
-    return Scaffold(
-      body: Center(
-        child: CircularProgressIndicator(
-          color: Theme.of(context).colorScheme.primary,
-        ),
-      ),
+  Future<void> _showEditGoalDialog() async {
+    final provider = context.read<RecordProvider>();
+    final result = await Navigator.push<GoalEditResult>(
+      context,
+      MaterialPageRoute(builder: (_) => const EditGoalPage()),
     );
+
+    if (!context.mounted || result == null) return;
+    final trimmed = result.title.trim();
+    if (trimmed.isEmpty) return;
+    final (result: addResult, goal: newGoal) = await provider.addGoal(trimmed);
+    if (addResult == AddGoalResult.success && newGoal != null) {
+      provider.setFocusedGoalForScroll(newGoal);
+      setState(() {});
+    }
   }
 }

--- a/lib/ui/goal_calendar/goal_calendar_page.dart
+++ b/lib/ui/goal_calendar/goal_calendar_page.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_pager.dart';
 
 class GoalCalendarPage extends StatefulWidget {

--- a/lib/ui/goal_calendar/goal_calendar_page.dart
+++ b/lib/ui/goal_calendar/goal_calendar_page.dart
@@ -45,7 +45,9 @@ class _GoalCalendarPageState extends State<GoalCalendarPage> {
     final provider = context.read<RecordProvider>();
     final result = await Navigator.push<GoalEditResult>(
       context,
-      MaterialPageRoute(builder: (_) => const EditGoalPage()),
+      MaterialPageRoute(
+        builder: (_) => const EditGoalPage(mode: GoalEditMode.create),
+      ),
     );
 
     if (!context.mounted || result == null) return;

--- a/lib/ui/goal_calendar/goal_edit_result.dart
+++ b/lib/ui/goal_calendar/goal_edit_result.dart
@@ -1,6 +1,8 @@
+enum GoalEditMode { create, update }
+
 class GoalEditResult {
   final String title;
-  final bool isNew;
+  final GoalEditMode mode;
 
-  GoalEditResult({required this.title, required this.isNew});
+  GoalEditResult({required this.title, required this.mode});
 }

--- a/lib/ui/goal_calendar/goal_edit_result.dart
+++ b/lib/ui/goal_calendar/goal_edit_result.dart
@@ -1,0 +1,6 @@
+class GoalEditResult {
+  final String title;
+  final bool isNew;
+
+  GoalEditResult({required this.title, required this.isNew});
+}

--- a/lib/ui/launcher/add_first_goal_flow.dart
+++ b/lib/ui/launcher/add_first_goal_flow.dart
@@ -21,7 +21,9 @@ class _AddFirstGoalFlowState extends State<AddFirstGoalFlow> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final result = await Navigator.push<GoalEditResult>(
         context,
-        MaterialPageRoute(builder: (_) => const EditGoalPage()),
+        MaterialPageRoute(
+          builder: (_) => const EditGoalPage(mode: GoalEditMode.create),
+        ),
       );
       if (!mounted || result == null) return;
       final trimmed = result.title.trim();

--- a/lib/ui/launcher/add_first_goal_flow.dart
+++ b/lib/ui/launcher/add_first_goal_flow.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
+import 'package:haenaedda/ui/widgets/loading_indicator.dart';
+
+class AddFirstGoalFlow extends StatefulWidget {
+  const AddFirstGoalFlow({super.key});
+
+  @override
+  State<AddFirstGoalFlow> createState() => _AddFirstGoalFlowState();
+}
+
+class _AddFirstGoalFlowState extends State<AddFirstGoalFlow> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final result = await Navigator.push<GoalEditResult>(
+        context,
+        MaterialPageRoute(builder: (_) => const EditGoalPage()),
+      );
+      if (!mounted || result == null) return;
+      final trimmed = result.title.trim();
+      if (trimmed.isEmpty) return;
+
+      final provider = context.read<RecordProvider>();
+      final (result: addResult, goal: newGoal) =
+          await provider.addGoal(trimmed);
+
+      if (addResult == AddGoalResult.success && newGoal != null) {
+        provider.setFocusedGoalForScroll(newGoal);
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => const GoalCalendarPage()),
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: LoadingIndicator());
+  }
+}

--- a/lib/ui/launcher/launcher_page.dart
+++ b/lib/ui/launcher/launcher_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:haenaedda/provider/record_provider.dart';
+import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
+import 'package:haenaedda/ui/launcher/add_first_goal_flow.dart';
+import 'package:haenaedda/ui/widgets/loading_indicator.dart';
+
+class LauncherPage extends StatelessWidget {
+  const LauncherPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<RecordProvider>();
+    if (!provider.isLoaded) {
+      return const Scaffold(body: LoadingIndicator());
+    }
+    if (provider.hasNoGoal) {
+      return const AddFirstGoalFlow();
+    }
+    return const GoalCalendarPage();
+  }
+}

--- a/lib/ui/settings/handlers/edit_goal_handler.dart
+++ b/lib/ui/settings/handlers/edit_goal_handler.dart
@@ -113,7 +113,9 @@ Future<void> onAddGoalPressed(BuildContext context) async {
   final recordProvider = context.read<RecordProvider>();
   final result = await Navigator.push<GoalEditResult>(
     context,
-    MaterialPageRoute(builder: (_) => const EditGoalPage()),
+    MaterialPageRoute(
+      builder: (_) => const EditGoalPage(mode: GoalEditMode.create),
+    ),
   );
 
   if (!context.mounted || result == null) return;
@@ -146,7 +148,10 @@ Future<String?> onEditGoalTitlePressed(BuildContext context, Goal goal) async {
   final recordProvider = context.read<RecordProvider>();
   final result = await Navigator.of(context).push<GoalEditResult>(
     MaterialPageRoute(
-      builder: (_) => EditGoalPage(initialText: goal.title),
+      builder: (_) => EditGoalPage(
+        initialText: goal.title,
+        mode: GoalEditMode.update,
+      ),
     ),
   );
 

--- a/lib/ui/widgets/loading_indicator.dart
+++ b/lib/ui/widgets/loading_indicator.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class LoadingIndicator extends StatelessWidget {
+  final double size;
+
+  const LoadingIndicator({super.key, this.size = 36});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.secondary;
+    return Center(
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: CircularProgressIndicator(
+          strokeWidth: 5,
+          valueColor: AlwaysStoppedAnimation<Color>(color),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 변경 목적
- 목표가 없을 경우, EditGoalPage가 중복 실행되거나 검은 화면에 머무르는 문제를 해결했습니다.
- 목표가 없을 때 진입하는 초기 플로우를 런처 페이지로 분리했습니다. 

## 주요 변경 사항
- GoalEditMode enum 도입 
- LauncherPage 도입
    - 목표 존재 여부를 기반으로 적절한 첫 화면으로 리디렉션
- addFirstGoalFlow.dart 도입
    - 목표가 없을 때 최초로 EditGoalPage를 호출하는 단일 책임 함수 분리

## 기대 효과
- 목표가 없을 때 자연스럽고 안정적인 플로우로 첫 목표를 생성할 수 있음
- 목표 추가/수정 플로우의 명확한 역할 분리
- 초기 화면에서 검은 화면/중복 화면 전환 등의 오류 제거

## 다음 계획
- Goal 편집 화면에서 validation 메시지 또는 에러 메시지 시각화 추가
