### PR TITLE
Feature: 다크 모드 지원을 위한 색상 대응 및 버튼 스타일 함수 공통화

### DIFF
--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -31,15 +31,15 @@ class AppColors {
   static const Color inverseSurface = Color(0xFF2C3E50);
   static const Color onInverseSurface = Color(0xFFECEFF4);
 
-  // Dark Theme Colors
+// Dark Theme Colors
   static const Color darkPrimary = Color(0xFF4A90E2);
   static const Color darkOnPrimary = Color(0xFFFFFFFF);
 
   static const Color darkSecondary = Color(0xFFA0BCE0);
   static const Color darkOnSecondary = Color(0xFF000000);
 
-  static const Color darkSurface = Color(0xFF121212);
-  static const Color darkOnSurface = Color(0xFFFFFFFF);
+  static const Color darkSurface = Color(0xFF1E1E1E);
+  static const Color darkOnSurface = Color(0xFFECECEC);
 
   static const Color darkError = Color(0xFFCF6679);
   static const Color darkOnError = Color(0xFF000000);
@@ -48,14 +48,14 @@ class AppColors {
 
   static const Color darkOnSurfaceVariant = Color(0xFFB0B0B0);
 
-  static const Color darkSurfaceContainerLowest = Color(0xFF121212);
-  static const Color darkSurfaceContainerLow = Color(0xFF1A1A1A);
-  static const Color darkSurfaceContainer = Color(0xFF1E1E1E);
-  static const Color darkSurfaceContainerHigh = Color(0xFF2C2C2C);
-  static const Color darkSurfaceContainerHighest = Color(0xFF3A3A3A);
+  static const Color darkSurfaceContainerLowest = Color(0xFF1E1E1E);
+  static const Color darkSurfaceContainerLow = Color(0xFF242424);
+  static const Color darkSurfaceContainer = Color(0xFF2A2A2A);
+  static const Color darkSurfaceContainerHigh = Color(0xFF303030);
+  static const Color darkSurfaceContainerHighest = Color(0xFF383838);
 
-  static const Color darkOutline = Color(0xFF3D3D3D);
-  static const Color darkOutlineVariant = Color(0xFF4A4A4A);
+  static const Color darkOutline = Color(0xFF4C4C4C);
+  static const Color darkOutlineVariant = Color(0xFF606060);
 
   static const Color darkInverseSurface = Color(0xFFECEFF4);
   static const Color darkOnInverseSurface = Color(0xFF2C3E50);

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -17,7 +17,7 @@ class AppColors {
   static const Color errorContainer = Color(0xFFF9DEDC);
   static const Color onErrorContainer = Color(0xFF410E0B);
 
-  static const Color hint = Color(0xFF8E8E93);
+  static const Color onSurfaceVariant = Color(0xFF8E8E93);
 
   static const Color surfaceContainerLowest = Color(0xFFD6DEE8);
   static const Color surfaceContainerLow = Color(0xFFE9EDF2);
@@ -33,7 +33,7 @@ class AppColors {
 
   // Dark Theme Colors
   static const Color darkPrimary = Color(0xFF4A90E2);
-  static const Color darkOnPrimary = Color(0xFF000000);
+  static const Color darkOnPrimary = Color(0xFFFFFFFF);
 
   static const Color darkSecondary = Color(0xFFA0BCE0);
   static const Color darkOnSecondary = Color(0xFF000000);
@@ -43,6 +43,10 @@ class AppColors {
 
   static const Color darkError = Color(0xFFCF6679);
   static const Color darkOnError = Color(0xFF000000);
+  static const Color darkErrorContainer = Color(0xFF8C1D18);
+  static const Color darkOnErrorContainer = Color(0xFFFFDAD6);
+
+  static const Color darkOnSurfaceVariant = Color(0xFFB0B0B0);
 
   static const Color darkSurfaceContainerLowest = Color(0xFF121212);
   static const Color darkSurfaceContainerLow = Color(0xFF1A1A1A);

--- a/lib/theme/buttons.dart
+++ b/lib/theme/buttons.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:haenaedda/theme/app_colors.dart';
 
-ButtonStyle getButtonStyle({
-  required Color background,
-  required Color foreground,
+ButtonStyle _getTextButtonStyle({
+  required Color backgroundColor,
+  required Color foregroundColor,
 }) {
   return ButtonStyle(
     padding: WidgetStateProperty.all(
       const EdgeInsets.symmetric(vertical: 14),
     ),
-    backgroundColor: WidgetStateProperty.all(background),
-    foregroundColor: WidgetStateProperty.all(foreground),
+    backgroundColor: WidgetStateProperty.all(backgroundColor),
+    foregroundColor: WidgetStateProperty.all(foregroundColor),
     overlayColor: WidgetStateProperty.resolveWith((states) {
       if (states.contains(WidgetState.pressed)) {
         return Colors.black.withValues(alpha: 0.04);
@@ -20,6 +21,45 @@ ButtonStyle getButtonStyle({
       RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
     ),
     splashFactory: NoSplash.splashFactory,
+  );
+}
+
+/// ✅ Used for primary actions like "Save", "Confirm", etc.
+/// Example: When the user is expected to proceed or submit data.
+ButtonStyle getPrimaryButtonStyle(BuildContext context) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+  final backgroundColor = isDark ? AppColors.darkPrimary : AppColors.primary;
+  final foregroundColor =
+      isDark ? AppColors.darkOnPrimary : AppColors.onPrimary;
+  return _getTextButtonStyle(
+    backgroundColor: backgroundColor,
+    foregroundColor: foregroundColor,
+  );
+}
+
+/// ✅ Used for neutral or secondary actions like "Cancel", "Close", etc.
+/// Example: When the action is not destructive and not the main flow.
+ButtonStyle getNeutralButtonStyle(BuildContext context) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+  final backgroundColor =
+      isDark ? AppColors.darkSurfaceContainer : AppColors.surfaceContainer;
+  final foregroundColor =
+      isDark ? AppColors.darkOnSurface : AppColors.onSurface;
+  return _getTextButtonStyle(
+    backgroundColor: backgroundColor,
+    foregroundColor: foregroundColor,
+  );
+}
+
+ButtonStyle getDestructiveButtonStyle(BuildContext context) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+  final backgroundColor =
+      isDark ? AppColors.darkError : AppColors.errorContainer;
+  final foregroundColor =
+      isDark ? AppColors.darkOnError : AppColors.onErrorContainer;
+  return _getTextButtonStyle(
+    backgroundColor: backgroundColor,
+    foregroundColor: foregroundColor,
   );
 }
 

--- a/lib/theme/color_scheme_dark.dart
+++ b/lib/theme/color_scheme_dark.dart
@@ -11,5 +11,8 @@ const darkColorScheme = ColorScheme(
   onSurface: AppColors.darkOnSurface,
   error: AppColors.darkError,
   onError: AppColors.darkOnError,
+  errorContainer: AppColors.darkErrorContainer,
+  onErrorContainer: AppColors.darkOnErrorContainer,
   outline: AppColors.darkOutline,
+  onSurfaceVariant: AppColors.darkOnSurfaceVariant,
 );

--- a/lib/theme/color_scheme_light.dart
+++ b/lib/theme/color_scheme_light.dart
@@ -14,4 +14,5 @@ const lightColorScheme = ColorScheme(
   errorContainer: AppColors.errorContainer,
   onErrorContainer: AppColors.onErrorContainer,
   outline: AppColors.outline,
+  onSurfaceVariant: AppColors.onSurfaceVariant,
 );

--- a/lib/theme/decorations/neumorphic_theme.dart
+++ b/lib/theme/decorations/neumorphic_theme.dart
@@ -9,81 +9,21 @@ class NeumorphicTheme {
   static const double blurRadius = 8;
   static BorderRadius defaultBorderRadius = BorderRadius.circular(12);
 
-  /// Pressed (Concave) Effect - Light Mode Only
-  /// - Looks pressed inward in light mode
-  static BoxDecoration pressedBoxDecoration(BuildContext context) {
-    return BoxDecoration(
-      color: Theme.of(context).colorScheme.surface,
-      borderRadius: defaultBorderRadius,
-      boxShadow: [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.05),
-          offset: deepTopLeftOffset,
-          blurRadius: blurRadius,
-        ),
-        BoxShadow(
-          color: Colors.white.withValues(alpha: 0.7),
-          offset: deepBottomRightOffset,
-          blurRadius: blurRadius,
-        ),
-      ],
-    );
-  }
-
-  /// Raised (Convex) Effect - Light Mode Only
-  /// - Looks raised outward in light mode
-  static BoxDecoration raisedBoxDecoration(BuildContext context) {
-    return BoxDecoration(
-      color: Theme.of(context).colorScheme.surface,
-      borderRadius: defaultBorderRadius,
-      boxShadow: [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.05),
-          offset: deepBottomRightOffset,
-          blurRadius: blurRadius,
-        ),
-        BoxShadow(
-          color: Colors.white.withValues(alpha: 0.7),
-          offset: deepTopLeftOffset,
-          blurRadius: blurRadius,
-        ),
-      ],
-    );
-  }
-
-  static BoxDecoration raisedSettingTileBoxDecoration(BuildContext context) {
-    return BoxDecoration(
-      color: Theme.of(context).colorScheme.surface,
-      borderRadius: BorderRadius.circular(16),
-      boxShadow: [
-        BoxShadow(
-          color: Colors.black.withValues(alpha: 0.07),
-          offset: bottomRightOffset,
-          blurRadius: 4,
-        ),
-        BoxShadow(
-          color: Colors.white.withValues(alpha: 0.6),
-          offset: topLeftOffset,
-          blurRadius: 6,
-        ),
-      ],
-    );
-  }
-
-  /// Light mode decoration for recorded (completed) cells
   static BoxDecoration recordedCellDecoration(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
     return BoxDecoration(
-      // TODO: Allow user to customize cell color
-      color: const Color(0xFFECE7E0),
+      color: isDark ? const Color(0xFF6B7380) : const Color(0xFFECE7E0),
       borderRadius: defaultBorderRadius,
       boxShadow: [
         BoxShadow(
-          color: Colors.white.withValues(alpha: 0.7),
-          offset: deepTopLeftOffset,
+          color: isDark
+              ? Colors.grey.withValues(alpha: 0.4)
+              : Colors.white.withValues(alpha: 0.7),
+          offset: isDark ? topLeftOffset : deepTopLeftOffset,
           blurRadius: blurRadius,
         ),
         BoxShadow(
-          color: Colors.black.withValues(alpha: 0.1),
+          color: Colors.black.withValues(alpha: isDark ? 0.7 : 0.1),
           offset: deepBottomRightOffset,
           blurRadius: blurRadius,
         ),
@@ -91,19 +31,22 @@ class NeumorphicTheme {
     );
   }
 
-  /// Light mode decoration for unrecorded cells
   static BoxDecoration unrecordedCellDecoration(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return BoxDecoration(
       color: Theme.of(context).colorScheme.surface,
       borderRadius: defaultBorderRadius,
       boxShadow: [
         BoxShadow(
-          color: Colors.white.withValues(alpha: 0.7),
+          color: isDark
+              ? Colors.grey.withValues(alpha: 0.1)
+              : Colors.white.withValues(alpha: 0.7),
           offset: bottomRightOffset,
           blurRadius: blurRadius,
         ),
         BoxShadow(
-          color: Colors.black.withValues(alpha: 0.1),
+          color: Colors.black.withValues(alpha: isDark ? 0.4 : 0.1),
           offset: topLeftOffset,
           blurRadius: blurRadius,
         ),
@@ -111,15 +54,19 @@ class NeumorphicTheme {
     );
   }
 
-  static List<BoxShadow> buttonShadow() {
+  static List<BoxShadow> buttonShadow(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return [
       BoxShadow(
-        color: Colors.black.withValues(alpha: 0.05),
+        color: Colors.black.withValues(alpha: isDark ? 0.7 : 0.05),
         offset: const Offset(2, 2),
         blurRadius: 5,
       ),
       BoxShadow(
-        color: Colors.white.withValues(alpha: 0.7),
+        color: isDark
+            ? Colors.grey.withValues(alpha: 0.1)
+            : Colors.white.withValues(alpha: 0.7),
         offset: const Offset(-2, -2),
         blurRadius: 5,
       ),

--- a/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/header_section/month_navigation_bar.dart
@@ -114,7 +114,7 @@ class _MonthNavigationBarState extends State<MonthNavigationBar> {
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surface,
             borderRadius: BorderRadius.circular(14),
-            boxShadow: NeumorphicTheme.buttonShadow(),
+            boxShadow: NeumorphicTheme.buttonShadow(context),
           ),
           child: Icon(
             isLeft ? Icons.chevron_left : Icons.chevron_right,

--- a/lib/ui/settings/handlers/edit_goal_handler.dart
+++ b/lib/ui/settings/handlers/edit_goal_handler.dart
@@ -76,10 +76,7 @@ Future<bool?> confirmDiscardChanges(BuildContext context) {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: TextButton(
-                        style: getButtonStyle(
-                          background: colorScheme.outline,
-                          foreground: colorScheme.onSurfaceVariant,
-                        ),
+                        style: getNeutralButtonStyle(context),
                         onPressed: () => Navigator.of(context).pop(false),
                         child:
                             Text(l10n.keepEditing, style: getButtonTextStyle()),
@@ -90,10 +87,7 @@ Future<bool?> confirmDiscardChanges(BuildContext context) {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: TextButton(
-                        style: getButtonStyle(
-                          background: colorScheme.onError,
-                          foreground: colorScheme.error,
-                        ),
+                        style: getDestructiveButtonStyle(context),
                         onPressed: () => Navigator.of(context).pop(true),
                         child: Text(l10n.leave, style: getButtonTextStyle()),
                       ),

--- a/lib/ui/settings/handlers/reset_goal_handler.dart
+++ b/lib/ui/settings/handlers/reset_goal_handler.dart
@@ -94,10 +94,7 @@ Future<bool?> showResetConfirmDialog(
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: TextButton(
-                        style: getButtonStyle(
-                          background: colorScheme.outline,
-                          foreground: colorScheme.onSurfaceVariant,
-                        ),
+                        style: getNeutralButtonStyle(context),
                         onPressed: () => Navigator.of(context).pop(),
                         child: Text(
                           l10n.cancel,
@@ -110,14 +107,11 @@ Future<bool?> showResetConfirmDialog(
                     child: Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: TextButton(
-                        style: getButtonStyle(
-                          background: colorScheme.onError,
-                          foreground: colorScheme.error,
-                        ),
+                        style: getDestructiveButtonStyle(context),
                         onPressed: () => Navigator.of(context).pop(true),
                         child: Text(
                           l10n.reset,
-                          style: getButtonTextStyle(color: colorScheme.error),
+                          style: getButtonTextStyle(color: colorScheme.onError),
                         ),
                       ),
                     ),

--- a/lib/ui/settings/neumorphic_settings_tile.dart
+++ b/lib/ui/settings/neumorphic_settings_tile.dart
@@ -16,6 +16,8 @@ class NeumorphicSettingsTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return GestureDetector(
       onTap: onTap,
       child: Container(
@@ -26,12 +28,14 @@ class NeumorphicSettingsTile extends StatelessWidget {
           borderRadius: BorderRadius.circular(16),
           boxShadow: [
             BoxShadow(
-              color: Colors.white.withValues(alpha: 0.6),
+              color: isDark
+                  ? Colors.grey.withValues(alpha: 0.4)
+                  : Colors.white.withValues(alpha: 0.6),
               offset: const Offset(-1, -1),
-              blurRadius: 10,
+              blurRadius: isDark ? 8 : 10,
             ),
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.01),
+              color: Colors.black.withValues(alpha: isDark ? 0.9 : 0.01),
               offset: const Offset(2, 2),
               blurRadius: 6,
             ),

--- a/lib/ui/widgets/bottom_right_button.dart
+++ b/lib/ui/widgets/bottom_right_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:haenaedda/constants/dimensions.dart';
 
+import 'package:haenaedda/constants/dimensions.dart';
 import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 
 class BottomRightButton extends StatelessWidget {
@@ -27,7 +27,7 @@ class BottomRightButton extends StatelessWidget {
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surface,
             shape: BoxShape.circle,
-            boxShadow: NeumorphicTheme.buttonShadow(),
+            boxShadow: NeumorphicTheme.buttonShadow(context),
           ),
           child: child,
         ),


### PR DESCRIPTION
## 변경 목적
- 기존 네오모픽 UI 요소들이 다크 모드에서 정돈되지 않은 색상을 사용하는 문제가 있었습니다. 
- 이를 해결하고자 색상을 추가/수정하여 시각적 일관성을 확보하고 모든 관련 요소에 다크 모드 대응을 적용하였습니다.
- 더불어 버튼 스타일 함수를 공통화하여 사용성을 향상했습니다.

## 주요 변경 사항
- NeumorphicTheme 전반에 다크 모드 대응 로직 추가
    - 그림자 색상, 위치, 알파값을 모드에 따라 분기 처리
    - MonthNavigationBar, BottomRightButton, SettingTile 등 컴포넌트에서 그림자 적용 방식 수정
- 버튼 스타일을 상황별로 분리
    - getPrimaryButtonStyle: 주 작업용 (예: 저장, 확인)
    - getNeutralButtonStyle: 보조 작업용 (예: 취소, 닫기)
    - getDestructiveButtonStyle: 위험 작업용 (예: 삭제, 초기화)

## 기대 효과
- 다크 모드에서도 자연스럽고 일관된 사용자 경험 제공
- 버튼 색상 및 그림자 표현이 각 모드에 적절하게 대응되어 가독성과 접근성 향상
- 테마와 디자인 리팩토링을 통해 유지보수성과 확장성 증가

## 다음 계획
- 사용자 커스터마이징이 가능한 색상 설정 기능 검토
