### PR TITLE
Refactor: 캘린더 날짜 흐름 통합 (MonthNavigationBar를 중심으로 한 상태 관리 개선)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
+import 'package:haenaedda/provider/calendar_month_provider.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/app_theme.dart';
 import 'package:haenaedda/ui/launcher/launcher_page.dart';
@@ -10,6 +11,7 @@ import 'package:haenaedda/ui/launcher/launcher_page.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final recordProvider = RecordProvider();
+  final calendarMonthProvider = CalendarDateProvider();
   await recordProvider.loadData();
 
   runApp(
@@ -18,6 +20,9 @@ Future<void> main() async {
         ChangeNotifierProvider<RecordProvider>.value(
           value: recordProvider,
         ),
+        ChangeNotifierProvider<CalendarDateProvider>.value(
+          value: calendarMonthProvider,
+        )
       ],
       child: const Haenaedda(),
     ),

--- a/lib/model/date_record_set.dart
+++ b/lib/model/date_record_set.dart
@@ -9,6 +9,8 @@ class DateRecordSet {
   DateRecordSet([Set<String>? initial]) : _dateKeys = initial ?? {};
 
   Set<String> get dateKeys => _dateKeys;
+  bool get isEmpty => _dateKeys.isEmpty;
+
   static DateRecordSet fromJson(String? jsonString) {
     if (jsonString == null || jsonString.trim().isEmpty) {
       return DateRecordSet();

--- a/lib/provider/calendar_month_provider.dart
+++ b/lib/provider/calendar_month_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:haenaedda/utils/extensions/date_compare_extension.dart';
+
+class CalendarDateProvider with ChangeNotifier {
+  late final DateTime _initialVisibleDate;
+  late DateTime _visibleDate;
+
+  CalendarDateProvider() {
+    final now = DateTime.now();
+    _initialVisibleDate = DateTime(now.year, now.month);
+    _visibleDate = _initialVisibleDate;
+  }
+
+  DateTime get visibleDate => _visibleDate;
+  DateTime get initialVisibleDate => _initialVisibleDate;
+
+  void updateDate(DateTime newDate) {
+    _visibleDate = newDate;
+    notifyListeners();
+  }
+
+  bool canGoToPrevious(DateTime firstRecordedDate) {
+    return visibleDate.isAfterYearMonthOf(firstRecordedDate);
+  }
+
+  bool canGoToNext(DateTime firstRecordedDate) {
+    return visibleDate.isBeforeYearMonthOf(initialVisibleDate);
+  }
+}

--- a/lib/provider/record_provider.dart
+++ b/lib/provider/record_provider.dart
@@ -253,6 +253,7 @@ class RecordProvider extends ChangeNotifier {
         final updatedGoalsJson =
             jsonEncode(goals.map((g) => g.toJson()).toList());
         final saved = await prefs.setString('goals', updatedGoalsJson);
+        _recordsByGoalId.remove(goalId);
         _syncSortedGoals();
         notifyListeners();
         return saved;

--- a/lib/ui/goal_calendar/calendar_day_cell.dart
+++ b/lib/ui/goal_calendar/calendar_day_cell.dart
@@ -29,7 +29,7 @@ class CalendarDayCell extends StatelessWidget {
           '${cellDate.day}',
           style: TextStyle(
             color: Theme.of(context).colorScheme.onSurface,
-            fontWeight: hasRecord ? FontWeight.bold : FontWeight.normal,
+            fontWeight: hasRecord ? FontWeight.w500 : FontWeight.w400,
           ),
         ),
       ),

--- a/lib/ui/goal_calendar/goal_calendar_content.dart
+++ b/lib/ui/goal_calendar/goal_calendar_content.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'package:haenaedda/model/calendar_grid_layout.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/app_spacing.dart';
@@ -26,11 +25,8 @@ class GoalCalendarContent extends StatefulWidget {
 }
 
 class _GoalCalendarContentState extends State<GoalCalendarContent> {
-  DateTime _focusedDate = DateTime.now();
-
   @override
   Widget build(BuildContext context) {
-    final dateLayout = CalendarGridLayout(_focusedDate);
     final goal = context.select<RecordProvider, Goal?>(
       (provider) => provider.getGoalById(widget.goal.id),
     );
@@ -40,14 +36,8 @@ class _GoalCalendarContentState extends State<GoalCalendarContent> {
       padding: const EdgeInsets.all(AppSpacing.medium),
       child: Column(
         children: [
-          const SizedBox(height: AppSpacing.tripleExtraLarge),
-          GoalCalendarHeader(
-            goal: goal,
-            date: _focusedDate,
-            onMonthChanged: (DateTime newMonth) {
-              setState(() => _focusedDate = newMonth);
-            },
-          ),
+          const SizedBox(height: AppSpacing.doubleExtraLarge),
+          GoalCalendarHeader(goal: goal),
           const SizedBox(height: AppSpacing.large),
           const SectionDivider(),
           const SizedBox(height: AppSpacing.doubleExtraLarge),

--- a/lib/ui/goal_calendar/goal_calendar_content.dart
+++ b/lib/ui/goal_calendar/goal_calendar_content.dart
@@ -45,7 +45,6 @@ class _GoalCalendarContentState extends State<GoalCalendarContent> {
           const SizedBox(height: AppSpacing.large),
           Expanded(
             child: GoalCalendarGrid(
-              dateLayout: dateLayout,
               cellBuilder: (cellDate) {
                 return Selector<RecordProvider, bool>(
                   selector: (_, provider) =>

--- a/lib/ui/goal_calendar/goal_calendar_grid.dart
+++ b/lib/ui/goal_calendar/goal_calendar_grid.dart
@@ -1,38 +1,41 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import 'package:haenaedda/model/calendar_grid_layout.dart';
+import 'package:haenaedda/provider/calendar_month_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/empty_cell.dart';
 
 class GoalCalendarGrid extends StatelessWidget {
-  final CalendarGridLayout dateLayout;
   final Widget Function(DateTime) cellBuilder;
 
-  const GoalCalendarGrid({
-    super.key,
-    required this.dateLayout,
-    required this.cellBuilder,
-  });
+  const GoalCalendarGrid({super.key, required this.cellBuilder});
 
   @override
   Widget build(BuildContext context) {
-    return GridView.builder(
-      physics: const NeverScrollableScrollPhysics(),
-      shrinkWrap: true,
-      itemCount: dateLayout.totalCellCount,
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 7,
-        mainAxisSpacing: 10,
-        crossAxisSpacing: 8,
-        childAspectRatio: 1,
-      ),
-      itemBuilder: (context, index) {
-        if (index < dateLayout.leadingBlanks ||
-            index >= dateLayout.leadingBlanks + dateLayout.totalDaysOfMonth) {
-          return const EmptyCell();
-        } else {
-          final cellDate = dateLayout.dateFromIndex(index);
-          return cellBuilder(cellDate);
-        }
+    return Selector<CalendarDateProvider, DateTime>(
+      selector: (_, provider) => provider.visibleDate,
+      builder: (_, focusedMonth, __) {
+        final layout = CalendarGridLayout(focusedMonth);
+        return GridView.builder(
+          physics: const NeverScrollableScrollPhysics(),
+          shrinkWrap: true,
+          itemCount: layout.totalCellCount,
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 7,
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+            childAspectRatio: 1.05,
+          ),
+          itemBuilder: (context, index) {
+            if (index < layout.leadingBlanks ||
+                index >= layout.leadingBlanks + layout.totalDaysOfMonth) {
+              return const EmptyCell();
+            } else {
+              final cellDate = layout.dateFromIndex(index);
+              return cellBuilder(cellDate);
+            }
+          },
+        );
       },
     );
   }

--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -33,9 +33,10 @@ class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
               child: Text(
                 title,
                 style: TextStyle(
-                  fontSize: 32,
+                  fontSize: 24,
                   color: Theme.of(context).colorScheme.onSurface,
                   fontWeight: FontWeight.bold,
+                  letterSpacing: -0.1,
                 ),
                 maxLines: 2,
               ),

--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -17,9 +17,9 @@ class GoalCalendarHeader extends StatefulWidget {
 class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
   @override
   Widget build(BuildContext context) {
-    final firstRecordMonth =
-        context.read<RecordProvider>().findFirstRecordedMonth(widget.goal.id);
-    if (firstRecordMonth == null) return const SizedBox.shrink();
+    final firstRecordDate =
+        context.read<RecordProvider>().findFirstRecordedDate(widget.goal.id);
+    if (firstRecordDate == null) return const SizedBox.shrink();
 
     return Column(
       children: [
@@ -44,7 +44,7 @@ class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
           },
         ),
         const SizedBox(height: 32),
-        MonthNavigationBar(firstRecordMonth: firstRecordMonth)
+        MonthNavigationBar(firstRecordMonth: firstRecordDate)
       ],
     );
   }

--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -54,13 +54,20 @@ class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
           },
         ),
         const SizedBox(height: 32),
-        MonthNavigationBar(
-          referenceDate: _currentMonth,
-          onMonthChanged: (newMonth) {
-            setState(() {
-              _currentMonth = newMonth;
-            });
-            widget.onMonthChanged?.call(newMonth);
+        Selector<RecordProvider, DateTime?>(
+          selector: (_, provider) => provider.findFirstRecordedDate(),
+          builder: (context, firstRecordMonth, child) {
+            if (firstRecordMonth == null) return const SizedBox.shrink();
+            return MonthNavigationBar(
+              initialFocusedDate: _currentMonth,
+              firstRecordMonth: firstRecordMonth,
+              onMonthChanged: (newMonth) {
+                setState(() {
+                  _currentMonth = newMonth;
+                });
+                widget.onMonthChanged?.call(newMonth);
+              },
+            );
           },
         ),
       ],

--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -7,31 +7,20 @@ import 'package:haenaedda/ui/goal_calendar/month_navigation_bar.dart';
 
 class GoalCalendarHeader extends StatefulWidget {
   final Goal goal;
-  final DateTime date;
-  final void Function(DateTime)? onMonthChanged;
 
-  const GoalCalendarHeader({
-    super.key,
-    required this.goal,
-    required this.date,
-    this.onMonthChanged,
-  });
+  const GoalCalendarHeader({super.key, required this.goal});
 
   @override
   State<GoalCalendarHeader> createState() => _GoalCalendarHeaderState();
 }
 
 class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
-  late DateTime _currentMonth;
-
-  @override
-  void initState() {
-    super.initState();
-    _currentMonth = widget.date;
-  }
-
   @override
   Widget build(BuildContext context) {
+    final firstRecordMonth =
+        context.read<RecordProvider>().findFirstRecordedMonth(widget.goal.id);
+    if (firstRecordMonth == null) return const SizedBox.shrink();
+
     return Column(
       children: [
         Selector<RecordProvider, String?>(
@@ -54,22 +43,7 @@ class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
           },
         ),
         const SizedBox(height: 32),
-        Selector<RecordProvider, DateTime?>(
-          selector: (_, provider) => provider.findFirstRecordedDate(),
-          builder: (context, firstRecordMonth, child) {
-            if (firstRecordMonth == null) return const SizedBox.shrink();
-            return MonthNavigationBar(
-              initialFocusedDate: _currentMonth,
-              firstRecordMonth: firstRecordMonth,
-              onMonthChanged: (newMonth) {
-                setState(() {
-                  _currentMonth = newMonth;
-                });
-                widget.onMonthChanged?.call(newMonth);
-              },
-            );
-          },
-        ),
+        MonthNavigationBar(firstRecordMonth: firstRecordMonth)
       ],
     );
   }

--- a/lib/ui/goal_calendar/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/month_navigation_bar.dart
@@ -1,112 +1,98 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
+import 'package:haenaedda/provider/calendar_month_provider.dart';
 import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 
-class MonthNavigationBar extends StatefulWidget {
-  final DateTime initialFocusedDate;
+class MonthNavigationBar extends StatelessWidget {
   final DateTime firstRecordMonth;
-  final void Function(DateTime)? onMonthChanged;
 
-  const MonthNavigationBar({
-    super.key,
-    required this.initialFocusedDate,
-    required this.firstRecordMonth,
-    this.onMonthChanged,
-  });
-
-  @override
-  State<MonthNavigationBar> createState() => _MonthNavigationBarState();
-}
-
-class _MonthNavigationBarState extends State<MonthNavigationBar> {
-  late DateTime _focusedDate;
-
-  @override
-  void initState() {
-    super.initState();
-    _focusedDate = widget.initialFocusedDate;
-  }
-
-  bool get isAtFirstRecordedMonth {
-    return _focusedDate.year == widget.firstRecordMonth.year &&
-        _focusedDate.month == widget.firstRecordMonth.month;
-  }
-
-  bool get isAtInitialFocusedMonth =>
-      _focusedDate.year == widget.initialFocusedDate.year &&
-      _focusedDate.month == widget.initialFocusedDate.month;
-
-  void _goToPreviousMonth() {
-    if (!isAtFirstRecordedMonth) {
-      setState(() {
-        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month - 1, 1);
-      });
-      widget.onMonthChanged?.call(_focusedDate);
-    }
-  }
-
-  void _goToNextMonth() {
-    if (!isAtInitialFocusedMonth) {
-      setState(() {
-        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month + 1, 1);
-      });
-      widget.onMonthChanged?.call(_focusedDate);
-    }
-  }
+  const MonthNavigationBar({super.key, required this.firstRecordMonth});
+  String _formatYearMonth(DateTime date) =>
+      '${date.year}.${date.month.toString().padLeft(2, '0')}';
 
   @override
   Widget build(BuildContext context) {
+    final provider = context.watch<CalendarDateProvider>();
+    final visibleDate = provider.visibleDate;
+    final canGoToPrevious = provider.canGoToPrevious(firstRecordMonth);
+    final canGoToNext = provider.canGoToNext(firstRecordMonth);
     final colorScheme = Theme.of(context).colorScheme;
+
     return ConstrainedBox(
       constraints: const BoxConstraints(
         minHeight: 48,
       ),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          if (!isAtFirstRecordedMonth)
-            _buildChevronButton(isLeft: true, onTap: _goToPreviousMonth),
+          _buildChevronButton(
+            context,
+            canGoToPrevious,
+            isLeft: true,
+            onTap: () {
+              final newMonth =
+                  DateTime(visibleDate.year, visibleDate.month - 1, 1);
+              provider.updateDate(newMonth);
+            },
+          ),
+          const SizedBox(width: 12),
           ConstrainedBox(
             constraints: BoxConstraints(
-              maxWidth: MediaQuery.of(context).size.width * 0.3,
+              maxWidth: MediaQuery.of(context).size.width * 0.4,
             ),
             child: FittedBox(
               fit: BoxFit.scaleDown,
               child: Text(
-                '${_focusedDate.year}.${_focusedDate.month.toString().padLeft(2, '0')}',
+                _formatYearMonth(visibleDate),
                 style: TextStyle(
                   color: colorScheme.onSurface,
-                  fontWeight: FontWeight.w400,
-                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  fontSize: 17,
+                  letterSpacing: 0.2,
                 ),
               ),
             ),
           ),
-          if (!isAtInitialFocusedMonth)
-            _buildChevronButton(isLeft: false, onTap: _goToNextMonth),
+          const SizedBox(width: 12),
+          _buildChevronButton(
+            context,
+            canGoToNext,
+            isLeft: false,
+            onTap: () {
+              final newMonth =
+                  DateTime(visibleDate.year, visibleDate.month + 1, 1);
+              provider.updateDate(newMonth);
+            },
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildChevronButton({
+  Widget _buildChevronButton(
+    BuildContext context,
+    bool showChevron, {
+    double width = 24.0,
     required bool isLeft,
     VoidCallback? onTap,
   }) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-          width: 36,
-          height: 36,
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
-            borderRadius: BorderRadius.circular(14),
-            boxShadow: NeumorphicTheme.buttonShadow(context),
-          ),
-          child: Icon(
-            isLeft ? Icons.chevron_left : Icons.chevron_right,
-            color: Theme.of(context).colorScheme.onSurface,
-          )),
-    );
+    return showChevron
+        ? GestureDetector(
+            onTap: onTap,
+            child: Container(
+                width: width,
+                height: width,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  borderRadius: BorderRadius.circular(14),
+                  boxShadow: NeumorphicTheme.buttonShadow(context),
+                ),
+                child: Icon(
+                  isLeft ? Icons.chevron_left : Icons.chevron_right,
+                  color: Theme.of(context).colorScheme.onSurface,
+                )),
+          )
+        : SizedBox(width: width, height: width);
   }
 }

--- a/lib/ui/goal_calendar/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/month_navigation_bar.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 
 class MonthNavigationBar extends StatefulWidget {
-  final DateTime referenceDate;
+  final DateTime initialFocusedDate;
+  final DateTime firstRecordMonth;
   final void Function(DateTime)? onMonthChanged;
 
   const MonthNavigationBar({
     super.key,
-    required this.referenceDate,
+    required this.initialFocusedDate,
+    required this.firstRecordMonth,
     this.onMonthChanged,
   });
 
@@ -20,48 +20,35 @@ class MonthNavigationBar extends StatefulWidget {
 
 class _MonthNavigationBarState extends State<MonthNavigationBar> {
   late DateTime _focusedDate;
-  DateTime? _firstRecordedDate;
 
   @override
   void initState() {
     super.initState();
-    _focusedDate = widget.referenceDate;
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _initFirstRecordedDateIfNeeded();
-  }
-
-  void _initFirstRecordedDateIfNeeded() {
-    _firstRecordedDate ??=
-        context.read<RecordProvider>().findFirstRecordedDate();
+    _focusedDate = widget.initialFocusedDate;
   }
 
   bool get isAtFirstRecordedMonth {
-    _initFirstRecordedDateIfNeeded();
-    return _focusedDate.year == _firstRecordedDate!.year &&
-        _focusedDate.month == _firstRecordedDate!.month;
+    return _focusedDate.year == widget.firstRecordMonth.year &&
+        _focusedDate.month == widget.firstRecordMonth.month;
   }
 
-  bool get isAtReferenceMonth =>
-      _focusedDate.year == widget.referenceDate.year &&
-      _focusedDate.month == widget.referenceDate.month;
+  bool get isAtInitialFocusedMonth =>
+      _focusedDate.year == widget.initialFocusedDate.year &&
+      _focusedDate.month == widget.initialFocusedDate.month;
 
   void _goToPreviousMonth() {
     if (!isAtFirstRecordedMonth) {
       setState(() {
-        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month - 1);
+        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month - 1, 1);
       });
       widget.onMonthChanged?.call(_focusedDate);
     }
   }
 
   void _goToNextMonth() {
-    if (!isAtReferenceMonth) {
+    if (!isAtInitialFocusedMonth) {
       setState(() {
-        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month + 1);
+        _focusedDate = DateTime(_focusedDate.year, _focusedDate.month + 1, 1);
       });
       widget.onMonthChanged?.call(_focusedDate);
     }
@@ -95,7 +82,7 @@ class _MonthNavigationBarState extends State<MonthNavigationBar> {
               ),
             ),
           ),
-          if (!isAtReferenceMonth)
+          if (!isAtInitialFocusedMonth)
             _buildChevronButton(isLeft: false, onTap: _goToNextMonth),
         ],
       ),

--- a/lib/ui/goal_calendar/weekday_row.dart
+++ b/lib/ui/goal_calendar/weekday_row.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 
 class WeekdayRow extends StatelessWidget {
@@ -15,9 +16,9 @@ class WeekdayRow extends StatelessWidget {
           return Text(
             daysOfWeek[index],
             style: TextStyle(
-              fontSize: 15,
+              fontSize: 14,
               color: Theme.of(context).colorScheme.onSurface,
-              fontWeight: FontWeight.bold,
+              fontWeight: FontWeight.w500,
             ),
             textAlign: TextAlign.center,
           );

--- a/lib/utils/extensions/date_compare_extension.dart
+++ b/lib/utils/extensions/date_compare_extension.dart
@@ -1,0 +1,13 @@
+extension DateCompare on DateTime {
+  bool isBeforeYearMonthOf(DateTime target) {
+    return year < target.year || (year == target.year && month < target.month);
+  }
+
+  bool isAfterYearMonthOf(DateTime target) {
+    return year > target.year || (year == target.year && month > target.month);
+  }
+
+  bool isSameYearMonthAs(DateTime target) {
+    return year == target.year && month == target.month;
+  }
+}


### PR DESCRIPTION
## 변경 목적
- 기존 MonthNavigationBar의 상태 관리를 StatefulWidget에서 Provider 기반의 StatelessWidget으로 전환했습니다.
- 날짜 계산 관련 로직을 CalendarDateProvider로 분리했습니다.
- 캘린더 셀/그리드 UI (비율, 여백, 폰트 등) 정리했습니다.
- 처음 기록된 날짜 계산에 대한 캐싱 적용했습니다. 

## 주요 변경 사항
- MonthNavigationBar를 StatelessWidget으로 변경
- CalendarDateProvider 상태 사용
    - 날짜 전환 가능 여부를 canGoToPrevious, canGoToNext로 분리
    - visibleDate, initialVisibleDate 관리 로직 추가
- 텍스트 스타일 (제목, 날짜 등) 및 그리드 여백/비율 조정
- RecordProvider에 _firstRecordDateCache 도입 및 무효화 로직 추가 (clearFirstRecordDateCache)
- UI 내 날짜 전환 시 발생하던 오류 수정 (6월 기록 있음/ 7월 기록 없음 -> 조건 오류로 6월에서 7월로 못넘어감) 

## 기대 효과
- 불필요한 상태 업데이트 방지로 성능 최적화
- 첫 기록 날짜 계산이 자주 반복되지 않도록 캐싱 처리하여 렌더링 속도 개선
- 캘린더 셀 및 전체 화면의 시각적 균형 및 일관성 향상

## 다음 계획
- GoalProvider 분리
- 목표 수 제한 설정 도입 및 관련 유효성 검증 UI 추가