### PR TITLE
Fix: GoalCalendarHeader 리팩토링 및 기록 없을 때 대응

### DIFF
--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -5,23 +5,17 @@ import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/month_navigation_bar.dart';
 
-class GoalCalendarHeader extends StatefulWidget {
+class GoalCalendarHeader extends StatelessWidget {
   final Goal goal;
 
   const GoalCalendarHeader({super.key, required this.goal});
 
   @override
-  State<GoalCalendarHeader> createState() => _GoalCalendarHeaderState();
-}
-
-class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
-  @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         Selector<RecordProvider, String?>(
-          selector: (_, provider) =>
-              provider.getGoalById(widget.goal.id)?.title,
+          selector: (_, provider) => provider.getGoalById(goal.id)?.title,
           builder: (context, title, _) {
             if (title == null) return const SizedBox.shrink();
             return Padding(
@@ -40,7 +34,7 @@ class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
           },
         ),
         const SizedBox(height: 32),
-        MonthNavigationBar(goalId: widget.goal.id)
+        MonthNavigationBar(goalId: goal.id)
       ],
     );
   }

--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -17,10 +17,6 @@ class GoalCalendarHeader extends StatefulWidget {
 class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
   @override
   Widget build(BuildContext context) {
-    final firstRecordDate =
-        context.read<RecordProvider>().findFirstRecordedDate(widget.goal.id);
-    if (firstRecordDate == null) return const SizedBox.shrink();
-
     return Column(
       children: [
         Selector<RecordProvider, String?>(
@@ -44,7 +40,7 @@ class _GoalCalendarHeaderState extends State<GoalCalendarHeader> {
           },
         ),
         const SizedBox(height: 32),
-        MonthNavigationBar(firstRecordMonth: firstRecordDate)
+        MonthNavigationBar(goalId: widget.goal.id)
       ],
     );
   }

--- a/lib/ui/goal_calendar/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/month_navigation_bar.dart
@@ -1,22 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:haenaedda/provider/record_provider.dart';
 import 'package:provider/provider.dart';
 
 import 'package:haenaedda/provider/calendar_month_provider.dart';
 import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
 
 class MonthNavigationBar extends StatelessWidget {
-  final DateTime firstRecordMonth;
+  final String goalId;
 
-  const MonthNavigationBar({super.key, required this.firstRecordMonth});
+  const MonthNavigationBar({super.key, required this.goalId});
+
   String _formatYearMonth(DateTime date) =>
       '${date.year}.${date.month.toString().padLeft(2, '0')}';
 
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<CalendarDateProvider>();
+    final firstRecordDate =
+        context.read<RecordProvider>().findFirstRecordedDate(goalId) ??
+            provider.initialVisibleDate;
     final visibleDate = provider.visibleDate;
-    final canGoToPrevious = provider.canGoToPrevious(firstRecordMonth);
-    final canGoToNext = provider.canGoToNext(firstRecordMonth);
+    final canGoToPrevious = provider.canGoToPrevious(firstRecordDate);
+    final canGoToNext = provider.canGoToNext(firstRecordDate);
     final colorScheme = Theme.of(context).colorScheme;
 
     return ConstrainedBox(


### PR DESCRIPTION
## 변경 목적
- 기록이 존재하지 않는 목표에 대해 null 예외 발생을 방지했습니다. 
- 관련된 GoalCalendarHeader를 Stateless Widget으로 변경시켰습니다.

## 주요 변경 사항
- GoalCalendarHeader을 StatefulWidget → StatelessWidget 전환
- firstRecordDate가 null인 경우에 initialVisibleDate를 fallback으로 처리

## 기대 효과
- 불필요한 상태 제거로 컴포넌트 단순화
- 기록이 없는 목표도 안전하게 렌더링 가능

##  다음 계획
- GoalProvider 분리