### PR TITLE
Refactor: 기록/목표 관리 로직을 분리하고 핸들러 중심으로 리팩토링 

### DIFF
--- a/lib/constants/storage_keys.dart
+++ b/lib/constants/storage_keys.dart
@@ -1,0 +1,4 @@
+class StorageKeys {
+  static const String goals = 'goals';
+  static const String record = 'record:';
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,32 +3,32 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
-import 'package:haenaedda/provider/calendar_month_provider.dart';
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/app_theme.dart';
 import 'package:haenaedda/ui/launcher/launcher_page.dart';
+import 'package:haenaedda/view_models/calendar_month_view_model.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  final recordProvider = RecordProvider();
-  final calendarMonthProvider = CalendarDateProvider();
-  await recordProvider.loadData();
+  final recordViewModel = RecordViewModel();
+  final calendarMonthViewModel = CalendarDateViewModel();
+  await recordViewModel.loadData();
 
   runApp(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider<RecordProvider>.value(
-          value: recordProvider,
+        ChangeNotifierProvider<RecordViewModel>.value(
+          value: recordViewModel,
         ),
-        ChangeNotifierProvider<CalendarDateProvider>.value(
-          value: calendarMonthProvider,
+        ChangeNotifierProvider<CalendarDateViewModel>.value(
+          value: calendarMonthViewModel,
         )
       ],
       child: const Haenaedda(),
     ),
   );
   WidgetsBinding.instance.addObserver(
-    _AppLifecycleObserver(onPause: () => recordProvider.saveAll()),
+    _AppLifecycleObserver(onPause: () => recordViewModel.saveAll()),
   );
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,19 +6,25 @@ import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/theme/app_theme.dart';
 import 'package:haenaedda/ui/launcher/launcher_page.dart';
 import 'package:haenaedda/view_models/calendar_month_view_model.dart';
+import 'package:haenaedda/view_models/goal_view_models.dart';
 import 'package:haenaedda/view_models/record_view_model.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final recordViewModel = RecordViewModel();
+  final goalViewModel = GoalViewModel();
   final calendarMonthViewModel = CalendarDateViewModel();
   await recordViewModel.loadData();
+  await goalViewModel.loadData();
 
   runApp(
     MultiProvider(
       providers: [
         ChangeNotifierProvider<RecordViewModel>.value(
           value: recordViewModel,
+        ),
+        ChangeNotifierProvider<GoalViewModel>.value(
+          value: goalViewModel,
         ),
         ChangeNotifierProvider<CalendarDateViewModel>.value(
           value: calendarMonthViewModel,
@@ -28,7 +34,10 @@ Future<void> main() async {
     ),
   );
   WidgetsBinding.instance.addObserver(
-    _AppLifecycleObserver(onPause: () => recordViewModel.saveAll()),
+    _AppLifecycleObserver(onPause: () async {
+      await recordViewModel.saveAllRecords();
+      await goalViewModel.saveAllGoals();
+    }),
   );
 }
 

--- a/lib/model/goal_setting_action.dart
+++ b/lib/model/goal_setting_action.dart
@@ -3,4 +3,5 @@ enum GoalSettingAction {
   editGoalTitle,
   resetRecordsOnly,
   resetEntireGoal,
+  resetAllGoals,
 }

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
 import 'package:haenaedda/ui/settings/handlers/edit_goal_handler.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 class EditGoalPage extends StatefulWidget {
   final String? initialText;
@@ -76,8 +76,8 @@ class _EditGoalPageState extends State<EditGoalPage> {
             backgroundColor: colorScheme.surface,
             leading: Builder(
               builder: (context) {
-                final hasNoGoal = context.select<RecordProvider, bool>(
-                  (provider) => provider.hasNoGoal,
+                final hasNoGoal = context.select<RecordViewModel, bool>(
+                  (recordViewModel) => recordViewModel.hasNoGoal,
                 );
                 if (hasNoGoal) return const SizedBox.shrink();
                 return IconButton(

--- a/lib/ui/goal_calendar/edit_goal_page.dart
+++ b/lib/ui/goal_calendar/edit_goal_page.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
 import 'package:haenaedda/ui/settings/handlers/edit_goal_handler.dart';
-import 'package:haenaedda/view_models/record_view_model.dart';
+import 'package:haenaedda/view_models/goal_view_models.dart';
 
 class EditGoalPage extends StatefulWidget {
   final String? initialText;
@@ -76,8 +76,8 @@ class _EditGoalPageState extends State<EditGoalPage> {
             backgroundColor: colorScheme.surface,
             leading: Builder(
               builder: (context) {
-                final hasNoGoal = context.select<RecordViewModel, bool>(
-                  (recordViewModel) => recordViewModel.hasNoGoal,
+                final hasNoGoal = context.select<GoalViewModel, bool>(
+                  (goalViewModel) => goalViewModel.hasNoGoal,
                 );
                 if (hasNoGoal) return const SizedBox.shrink();
                 return IconButton(

--- a/lib/ui/goal_calendar/goal_calendar_content.dart
+++ b/lib/ui/goal_calendar/goal_calendar_content.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:haenaedda/model/goal.dart';
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/app_spacing.dart';
 import 'package:haenaedda/ui/goal_calendar/calendar_day_cell.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_grid.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_header.dart';
 import 'package:haenaedda/ui/goal_calendar/weekday_row.dart';
 import 'package:haenaedda/ui/widgets/section_divider.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 class GoalCalendarContent extends StatefulWidget {
   final Goal goal;
@@ -27,8 +27,8 @@ class GoalCalendarContent extends StatefulWidget {
 class _GoalCalendarContentState extends State<GoalCalendarContent> {
   @override
   Widget build(BuildContext context) {
-    final goal = context.select<RecordProvider, Goal?>(
-      (provider) => provider.getGoalById(widget.goal.id),
+    final goal = context.select<RecordViewModel, Goal?>(
+      (recordViewModel) => recordViewModel.getGoalById(widget.goal.id),
     );
     if (goal == null) return const SizedBox.shrink();
 
@@ -46,9 +46,10 @@ class _GoalCalendarContentState extends State<GoalCalendarContent> {
           Expanded(
             child: GoalCalendarGrid(
               cellBuilder: (cellDate) {
-                return Selector<RecordProvider, bool>(
-                  selector: (_, provider) =>
-                      provider.getRecords(goal.id)?.contains(cellDate) ?? false,
+                return Selector<RecordViewModel, bool>(
+                  selector: (_, recordViewModel) =>
+                      recordViewModel.getRecords(goal.id)?.contains(cellDate) ??
+                      false,
                   builder: (_, hasRecord, __) => CalendarDayCell(
                     key: ValueKey(cellDate),
                     goalId: goal.id,

--- a/lib/ui/goal_calendar/goal_calendar_content.dart
+++ b/lib/ui/goal_calendar/goal_calendar_content.dart
@@ -8,6 +8,7 @@ import 'package:haenaedda/ui/goal_calendar/goal_calendar_grid.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_header.dart';
 import 'package:haenaedda/ui/goal_calendar/weekday_row.dart';
 import 'package:haenaedda/ui/widgets/section_divider.dart';
+import 'package:haenaedda/view_models/goal_view_models.dart';
 import 'package:haenaedda/view_models/record_view_model.dart';
 
 class GoalCalendarContent extends StatefulWidget {
@@ -27,17 +28,17 @@ class GoalCalendarContent extends StatefulWidget {
 class _GoalCalendarContentState extends State<GoalCalendarContent> {
   @override
   Widget build(BuildContext context) {
-    final goal = context.select<RecordViewModel, Goal?>(
-      (recordViewModel) => recordViewModel.getGoalById(widget.goal.id),
+    final goalViewModel = context.select<GoalViewModel, Goal?>(
+      (goalViewModel) => goalViewModel.getGoalById(widget.goal.id),
     );
-    if (goal == null) return const SizedBox.shrink();
+    if (goalViewModel == null) return const SizedBox.shrink();
 
     return Padding(
       padding: const EdgeInsets.all(AppSpacing.medium),
       child: Column(
         children: [
           const SizedBox(height: AppSpacing.doubleExtraLarge),
-          GoalCalendarHeader(goal: goal),
+          GoalCalendarHeader(goal: goalViewModel),
           const SizedBox(height: AppSpacing.large),
           const SectionDivider(),
           const SizedBox(height: AppSpacing.doubleExtraLarge),
@@ -48,11 +49,13 @@ class _GoalCalendarContentState extends State<GoalCalendarContent> {
               cellBuilder: (cellDate) {
                 return Selector<RecordViewModel, bool>(
                   selector: (_, recordViewModel) =>
-                      recordViewModel.getRecords(goal.id)?.contains(cellDate) ??
+                      recordViewModel
+                          .getRecords(goalViewModel.id)
+                          ?.contains(cellDate) ??
                       false,
                   builder: (_, hasRecord, __) => CalendarDayCell(
                     key: ValueKey(cellDate),
-                    goalId: goal.id,
+                    goalId: goalViewModel.id,
                     cellDate: cellDate,
                     hasRecord: hasRecord,
                     onTap: (goalId, date) => widget.onCellTap(goalId, cellDate),

--- a/lib/ui/goal_calendar/goal_calendar_grid.dart
+++ b/lib/ui/goal_calendar/goal_calendar_grid.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:haenaedda/model/calendar_grid_layout.dart';
-import 'package:haenaedda/provider/calendar_month_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/empty_cell.dart';
+import 'package:haenaedda/view_models/calendar_month_view_model.dart';
 
 class GoalCalendarGrid extends StatelessWidget {
   final Widget Function(DateTime) cellBuilder;
@@ -12,8 +12,8 @@ class GoalCalendarGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Selector<CalendarDateProvider, DateTime>(
-      selector: (_, provider) => provider.visibleDate,
+    return Selector<CalendarDateViewModel, DateTime>(
+      selector: (_, dateViewModel) => dateViewModel.visibleDate,
       builder: (_, focusedMonth, __) {
         final layout = CalendarGridLayout(focusedMonth);
         return GridView.builder(

--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:haenaedda/model/goal.dart';
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/month_navigation_bar.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 class GoalCalendarHeader extends StatelessWidget {
   final Goal goal;
@@ -14,8 +14,9 @@ class GoalCalendarHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Selector<RecordProvider, String?>(
-          selector: (_, provider) => provider.getGoalById(goal.id)?.title,
+        Selector<RecordViewModel, String?>(
+          selector: (_, recordViewModel) =>
+              recordViewModel.getGoalById(goal.id)?.title,
           builder: (context, title, _) {
             if (title == null) return const SizedBox.shrink();
             return Padding(

--- a/lib/ui/goal_calendar/goal_calendar_header.dart
+++ b/lib/ui/goal_calendar/goal_calendar_header.dart
@@ -3,7 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/ui/goal_calendar/month_navigation_bar.dart';
-import 'package:haenaedda/view_models/record_view_model.dart';
+import 'package:haenaedda/view_models/goal_view_models.dart';
 
 class GoalCalendarHeader extends StatelessWidget {
   final Goal goal;
@@ -14,9 +14,9 @@ class GoalCalendarHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Selector<RecordViewModel, String?>(
-          selector: (_, recordViewModel) =>
-              recordViewModel.getGoalById(goal.id)?.title,
+        Selector<GoalViewModel, String?>(
+          selector: (_, goalViewModel) =>
+              goalViewModel.getGoalById(goal.id)?.title,
           builder: (context, title, _) {
             if (title == null) return const SizedBox.shrink();
             return Padding(

--- a/lib/ui/goal_calendar/goal_calendar_page.dart
+++ b/lib/ui/goal_calendar/goal_calendar_page.dart
@@ -105,7 +105,6 @@ class _GoalCalendarPageState extends State<GoalCalendarPage> {
   }
 
   Future<void> _onSettingButtonTap(BuildContext context, Goal goal) async {
-    final recordViewModel = context.read<RecordViewModel>();
     final action = await showGeneralDialog<GoalSettingAction?>(
       context: context,
       barrierDismissible: true,
@@ -135,10 +134,13 @@ class _GoalCalendarPageState extends State<GoalCalendarPage> {
         await onEditGoalTitlePressed(context, goal);
         break;
       case GoalSettingAction.resetRecordsOnly:
-        recordViewModel.removeRecordsOnly(goal.id);
+        await handleResetRecordsOnly(context, goal);
         break;
       case GoalSettingAction.resetEntireGoal:
-        recordViewModel.resetEntireGoal(goal.id);
+        await handleResetEntireGoal(context, goal);
+        break;
+      case GoalSettingAction.resetAllGoals:
+        await handleResetAllGoals(context);
         break;
       case null:
         break;

--- a/lib/ui/goal_calendar/month_navigation_bar.dart
+++ b/lib/ui/goal_calendar/month_navigation_bar.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:provider/provider.dart';
 
-import 'package:haenaedda/provider/calendar_month_provider.dart';
 import 'package:haenaedda/theme/decorations/neumorphic_theme.dart';
+import 'package:haenaedda/view_models/calendar_month_view_model.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 class MonthNavigationBar extends StatelessWidget {
   final String goalId;
@@ -15,13 +15,13 @@ class MonthNavigationBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<CalendarDateProvider>();
+    final recordViewModel = context.watch<CalendarDateViewModel>();
     final firstRecordDate =
-        context.read<RecordProvider>().findFirstRecordedDate(goalId) ??
-            provider.initialVisibleDate;
-    final visibleDate = provider.visibleDate;
-    final canGoToPrevious = provider.canGoToPrevious(firstRecordDate);
-    final canGoToNext = provider.canGoToNext(firstRecordDate);
+        context.read<RecordViewModel>().findFirstRecordedDate(goalId) ??
+            recordViewModel.initialVisibleDate;
+    final visibleDate = recordViewModel.visibleDate;
+    final canGoToPrevious = recordViewModel.canGoToPrevious(firstRecordDate);
+    final canGoToNext = recordViewModel.canGoToNext(firstRecordDate);
     final colorScheme = Theme.of(context).colorScheme;
 
     return ConstrainedBox(
@@ -38,7 +38,7 @@ class MonthNavigationBar extends StatelessWidget {
             onTap: () {
               final newMonth =
                   DateTime(visibleDate.year, visibleDate.month - 1, 1);
-              provider.updateDate(newMonth);
+              recordViewModel.updateDate(newMonth);
             },
           ),
           const SizedBox(width: 12),
@@ -67,7 +67,7 @@ class MonthNavigationBar extends StatelessWidget {
             onTap: () {
               final newMonth =
                   DateTime(visibleDate.year, visibleDate.month + 1, 1);
-              provider.updateDate(newMonth);
+              recordViewModel.updateDate(newMonth);
             },
           ),
         ],

--- a/lib/ui/launcher/launcher_page.dart
+++ b/lib/ui/launcher/launcher_page.dart
@@ -1,21 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
 import 'package:haenaedda/ui/launcher/add_first_goal_flow.dart';
 import 'package:haenaedda/ui/widgets/loading_indicator.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 class LauncherPage extends StatelessWidget {
   const LauncherPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final provider = context.watch<RecordProvider>();
-    if (!provider.isLoaded) {
+    final recordViewModel = context.watch<RecordViewModel>();
+    if (!recordViewModel.isLoaded) {
       return const Scaffold(body: LoadingIndicator());
     }
-    if (provider.hasNoGoal) {
+    if (recordViewModel.hasNoGoal) {
       return const AddFirstGoalFlow();
     }
     return const GoalCalendarPage();

--- a/lib/ui/launcher/launcher_page.dart
+++ b/lib/ui/launcher/launcher_page.dart
@@ -4,18 +4,18 @@ import 'package:provider/provider.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
 import 'package:haenaedda/ui/launcher/add_first_goal_flow.dart';
 import 'package:haenaedda/ui/widgets/loading_indicator.dart';
-import 'package:haenaedda/view_models/record_view_model.dart';
+import 'package:haenaedda/view_models/goal_view_models.dart';
 
 class LauncherPage extends StatelessWidget {
   const LauncherPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final recordViewModel = context.watch<RecordViewModel>();
-    if (!recordViewModel.isLoaded) {
+    final goalViewModel = context.watch<GoalViewModel>();
+    if (!goalViewModel.isLoaded) {
       return const Scaffold(body: LoadingIndicator());
     }
-    if (recordViewModel.hasNoGoal) {
+    if (goalViewModel.hasNoGoal) {
       return const AddFirstGoalFlow();
     }
     return const GoalCalendarPage();

--- a/lib/ui/settings/handlers/edit_goal_handler.dart
+++ b/lib/ui/settings/handlers/edit_goal_handler.dart
@@ -3,11 +3,11 @@ import 'package:provider/provider.dart';
 
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/buttons.dart';
 import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 Future<void> onDiscardDuringInput(
     BuildContext context, TextEditingController controller) async {
@@ -107,7 +107,7 @@ Future<(AddGoalResult, Goal?)> showAddGoalFlow(
   BuildContext context, {
   bool replaceToGoalCalendar = false,
 }) async {
-  final recordProvider = context.read<RecordProvider>();
+  final recordViewModel = context.read<RecordViewModel>();
   final result = await Navigator.push<GoalEditResult>(
     context,
     MaterialPageRoute(
@@ -120,10 +120,10 @@ Future<(AddGoalResult, Goal?)> showAddGoalFlow(
 
   final trimmedTitle = result.title.trim();
   final (result: addResult, goal: newGoal) =
-      await recordProvider.addGoal(trimmedTitle);
+      await recordViewModel.addGoal(trimmedTitle);
 
   if (addResult == AddGoalResult.success && newGoal != null) {
-    recordProvider.setFocusedGoalForScroll(newGoal);
+    recordViewModel.setFocusedGoalForScroll(newGoal);
     if (replaceToGoalCalendar) {
       Navigator.pushReplacement(
         context,
@@ -135,7 +135,7 @@ Future<(AddGoalResult, Goal?)> showAddGoalFlow(
 }
 
 Future<String?> onEditGoalTitlePressed(BuildContext context, Goal goal) async {
-  final recordProvider = context.read<RecordProvider>();
+  final recordViewModel = context.read<RecordViewModel>();
   final result = await Navigator.of(context).push<GoalEditResult>(
     MaterialPageRoute(
       builder: (_) => EditGoalPage(
@@ -150,7 +150,7 @@ Future<String?> onEditGoalTitlePressed(BuildContext context, Goal goal) async {
   if (trimmedTitle.isEmpty && trimmedTitle == goal.title) return null;
 
   final (result: editResult, goal: renamedGoal) =
-      await recordProvider.renameGoal(goal, trimmedTitle);
+      await recordViewModel.renameGoal(goal, trimmedTitle);
   switch (editResult) {
     case RenameGoalResult.emptyInput:
       break;
@@ -162,7 +162,7 @@ Future<String?> onEditGoalTitlePressed(BuildContext context, Goal goal) async {
       break;
     case RenameGoalResult.success:
       if (renamedGoal != null) {
-        recordProvider.setFocusedGoalForScroll(renamedGoal);
+        recordViewModel.setFocusedGoalForScroll(renamedGoal);
         Navigator.pushReplacement(
           context,
           MaterialPageRoute(builder: (_) => const GoalCalendarPage()),

--- a/lib/ui/settings/handlers/edit_goal_handler.dart
+++ b/lib/ui/settings/handlers/edit_goal_handler.dart
@@ -7,7 +7,8 @@ import 'package:haenaedda/theme/buttons.dart';
 import 'package:haenaedda/ui/goal_calendar/edit_goal_page.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_edit_result.dart';
-import 'package:haenaedda/view_models/record_view_model.dart';
+import 'package:haenaedda/view_models/goal_result.dart';
+import 'package:haenaedda/view_models/goal_view_models.dart';
 
 Future<void> onDiscardDuringInput(
     BuildContext context, TextEditingController controller) async {
@@ -107,7 +108,7 @@ Future<(AddGoalResult, Goal?)> showAddGoalFlow(
   BuildContext context, {
   bool replaceToGoalCalendar = false,
 }) async {
-  final recordViewModel = context.read<RecordViewModel>();
+  final goalViewModel = context.read<GoalViewModel>();
   final result = await Navigator.push<GoalEditResult>(
     context,
     MaterialPageRoute(
@@ -120,10 +121,10 @@ Future<(AddGoalResult, Goal?)> showAddGoalFlow(
 
   final trimmedTitle = result.title.trim();
   final (result: addResult, goal: newGoal) =
-      await recordViewModel.addGoal(trimmedTitle);
+      await goalViewModel.addGoal(trimmedTitle);
 
   if (addResult == AddGoalResult.success && newGoal != null) {
-    recordViewModel.setFocusedGoalForScroll(newGoal);
+    goalViewModel.setFocusedGoalForScroll(newGoal);
     if (replaceToGoalCalendar) {
       Navigator.pushReplacement(
         context,
@@ -135,7 +136,7 @@ Future<(AddGoalResult, Goal?)> showAddGoalFlow(
 }
 
 Future<String?> onEditGoalTitlePressed(BuildContext context, Goal goal) async {
-  final recordViewModel = context.read<RecordViewModel>();
+  final goalViewModel = context.read<GoalViewModel>();
   final result = await Navigator.of(context).push<GoalEditResult>(
     MaterialPageRoute(
       builder: (_) => EditGoalPage(
@@ -150,7 +151,7 @@ Future<String?> onEditGoalTitlePressed(BuildContext context, Goal goal) async {
   if (trimmedTitle.isEmpty && trimmedTitle == goal.title) return null;
 
   final (result: editResult, goal: renamedGoal) =
-      await recordViewModel.renameGoal(goal, trimmedTitle);
+      await goalViewModel.renameGoal(goal, trimmedTitle);
   switch (editResult) {
     case RenameGoalResult.emptyInput:
       break;
@@ -162,7 +163,7 @@ Future<String?> onEditGoalTitlePressed(BuildContext context, Goal goal) async {
       break;
     case RenameGoalResult.success:
       if (renamedGoal != null) {
-        recordViewModel.setFocusedGoalForScroll(renamedGoal);
+        goalViewModel.setFocusedGoalForScroll(renamedGoal);
         Navigator.pushReplacement(
           context,
           MaterialPageRoute(builder: (_) => const GoalCalendarPage()),

--- a/lib/ui/settings/handlers/reset_goal_handler.dart
+++ b/lib/ui/settings/handlers/reset_goal_handler.dart
@@ -4,9 +4,9 @@ import 'package:provider/provider.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/model/goal.dart';
 import 'package:haenaedda/model/reset_type.dart';
-import 'package:haenaedda/provider/record_provider.dart';
 import 'package:haenaedda/theme/buttons.dart';
 import 'package:haenaedda/ui/goal_calendar/goal_calendar_page.dart';
+import 'package:haenaedda/view_models/record_view_model.dart';
 
 Future<void> showResetFailureDialog(BuildContext context, ResetType type) {
   final l10n = AppLocalizations.of(context)!;
@@ -149,8 +149,8 @@ Future<void> onResetButtonTap(
 }
 
 Future<void> _handleRecordOnlyReset(BuildContext context, Goal goal) async {
-  final provider = context.read<RecordProvider>();
-  final success = await provider.removeRecordsOnly(goal.id);
+  final recordViewModel = context.read<RecordViewModel>();
+  final success = await recordViewModel.removeRecordsOnly(goal.id);
 
   if (!context.mounted) return;
   if (success) {
@@ -164,18 +164,19 @@ Future<void> _handleRecordOnlyReset(BuildContext context, Goal goal) async {
 }
 
 Future<void> _handleEntireGoalReset(BuildContext context, Goal goal) async {
-  final provider = context.read<RecordProvider>();
-  final removedGoalIndex = provider.getNextFocusGoalIndexAfterRemoval(goal.id);
-  final result = await provider.resetEntireGoal(goal.id);
+  final recordViewModel = context.read<RecordViewModel>();
+  final removedGoalIndex =
+      recordViewModel.getNextFocusGoalIndexAfterRemoval(goal.id);
+  final result = await recordViewModel.resetEntireGoal(goal.id);
 
   if (!context.mounted) return;
 
   switch (result) {
     case ResetEntireGoalResult.success:
       if (removedGoalIndex != null &&
-          removedGoalIndex < provider.sortedGoals.length) {
-        final nextGoal = provider.sortedGoals[removedGoalIndex];
-        provider.setFocusedGoalForScroll(nextGoal);
+          removedGoalIndex < recordViewModel.sortedGoals.length) {
+        final nextGoal = recordViewModel.sortedGoals[removedGoalIndex];
+        recordViewModel.setFocusedGoalForScroll(nextGoal);
       }
       Navigator.pushReplacement(
         context,
@@ -192,8 +193,8 @@ Future<void> _handleEntireGoalReset(BuildContext context, Goal goal) async {
 }
 
 Future<void> _handleAllGoalsReset(BuildContext context) async {
-  final provider = context.read<RecordProvider>();
-  final result = await provider.resetAllGoals();
+  final recordViewModel = context.read<RecordViewModel>();
+  final result = await recordViewModel.resetAllGoals();
   if (!context.mounted) return;
   switch (result) {
     case ResetAllGoalsResult.success:

--- a/lib/view_models/calendar_month_view_model.dart
+++ b/lib/view_models/calendar_month_view_model.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:haenaedda/utils/extensions/date_compare_extension.dart';
 
-class CalendarDateProvider with ChangeNotifier {
+class CalendarDateViewModel with ChangeNotifier {
   late final DateTime _initialVisibleDate;
   late DateTime _visibleDate;
 
-  CalendarDateProvider() {
+  CalendarDateViewModel() {
     final now = DateTime.now();
     _initialVisibleDate = DateTime(now.year, now.month);
     _visibleDate = _initialVisibleDate;

--- a/lib/view_models/goal_result.dart
+++ b/lib/view_models/goal_result.dart
@@ -1,0 +1,25 @@
+enum AddGoalResult {
+  success,
+  emptyInput,
+  duplicate,
+  saveFailed,
+}
+
+enum RenameGoalResult {
+  success,
+  emptyInput,
+  notFound,
+  duplicate,
+  saveFailed,
+}
+
+enum ResetEntireGoalResult {
+  success,
+  recordFailed,
+  goalFailed,
+}
+
+enum ResetAllGoalsResult {
+  success,
+  failure,
+}

--- a/lib/view_models/record_view_model.dart
+++ b/lib/view_models/record_view_model.dart
@@ -15,32 +15,6 @@ class StorageKeys {
   static const String record = 'record:';
 }
 
-enum AddGoalResult {
-  success,
-  emptyInput,
-  duplicate,
-  saveFailed,
-}
-
-enum RenameGoalResult {
-  success,
-  emptyInput,
-  notFound,
-  duplicate,
-  saveFailed,
-}
-
-enum ResetEntireGoalResult {
-  success,
-  recordFailed,
-  goalFailed,
-}
-
-enum ResetAllGoalsResult {
-  success,
-  failure,
-}
-
 class RecordViewModel extends ChangeNotifier {
   final List<Goal> _goals = [];
   List<Goal> _sortedGoals = [];

--- a/lib/view_models/record_view_model.dart
+++ b/lib/view_models/record_view_model.dart
@@ -41,7 +41,7 @@ enum ResetAllGoalsResult {
   failure,
 }
 
-class RecordProvider extends ChangeNotifier {
+class RecordViewModel extends ChangeNotifier {
   final List<Goal> _goals = [];
   List<Goal> _sortedGoals = [];
   final Map<String, DateRecordSet> _recordsByGoalId = {};
@@ -52,7 +52,7 @@ class RecordProvider extends ChangeNotifier {
   final Map<String, DateTime> _firstRecordDateCache = {};
   late final Future<SharedPreferences> _sharedPrefsFuture;
 
-  RecordProvider() {
+  RecordViewModel() {
     _sharedPrefsFuture = SharedPreferences.getInstance();
   }
 


### PR DESCRIPTION
## 변경 목적
기존 RecordViewModel에 혼재되어 있던 목표 및 기록 관리 로직을 명확히 분리했습니다. 
Provider는 ViewModel로 명확히 역할을 정의하고, 사용자 액션 처리는 Handler를 통해 이루어지도록 구조를 정리했습니다.

## 주요 변경 사항
- GoalViewModel을 도입하여 목표 관리 로직(add, rename, remove, reset, 정렬 등)을 분리
- 분리하며 loadData, saveAll 등 명확한 책임 단위로 메서드 재정의 및 리네이밍
- RecordViewModel은 기록 관련 기능만 담당하도록 정리 (removeRecords, saveAllRecords 등)
- 사용자 액션 처리는 핸들러를 통해 이루어지도록 리팩토링 

## 기대 효과
- Handler → ViewModel → Storage 흐름이 전보다 정돈되어 가독성 향상 
- 코드 중복 제거 및 관심사 분리를 통해 코드 가독성과 테스트 용이성 향상

## 다음 계획
- Goal/Record 각각의 뷰모델 단위 테스트 작성
- 목표 정렬/순서 변경 UI 