### PR TITLE
Feature: 목표 수 제한 정책 도입

### DIFF
--- a/lib/domain/enums/goal_operation_result.dart
+++ b/lib/domain/enums/goal_operation_result.dart
@@ -3,6 +3,7 @@ enum AddGoalResult {
   emptyInput,
   duplicate,
   saveFailed,
+  limitExceeded,
 }
 
 enum RenameGoalResult {

--- a/lib/domain/policies/default_goal_policy.dart
+++ b/lib/domain/policies/default_goal_policy.dart
@@ -1,0 +1,3 @@
+import 'package:haenaedda/domain/policies/goal_policy.dart';
+
+const defaultGoalPolicy = GoalPolicy(maxGoalCount: 5);

--- a/lib/domain/policies/goal_policy.dart
+++ b/lib/domain/policies/goal_policy.dart
@@ -1,0 +1,5 @@
+class GoalPolicy {
+  final int maxGoalCount;
+
+  const GoalPolicy({required this.maxGoalCount});
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -144,10 +144,31 @@
         "description": "A prompt shown when the user is editing an existing goal",
         "type": "text"
     },
-      
     "reorderGoals": "Reorder Goals",
         "@reorderGoals": {
             "description": "Title or label for the screen where users can change the order of their goals",
             "type": "text"
+    },
+    "goalLimitTitle": "Goal Limit Reached",
+    "@goalLimitTitle": {
+        "description": "Title shown when the user tries to add a goal but has reached the goal limit",
+        "type": "text"
+    },
+    "goalLimitMessage": "You can have up to {maxGoalCount} goals.\nRemove an existing goal to add a new one.",
+    "@goalLimitMessage": {
+        "description": "Message shown when the user has reached the goal creation limit.",
+        "type": "text",
+        "placeholders": {
+            "maxGoalCount": {
+                "type": "int",
+                "example": "5",
+                "description": "The maximum number of goals a user can have"
+            }
         }
+    },
+    "ok": "OK",
+    "@ok": {
+        "description": "Generic confirmation button for dismissing dialogs without performing an action",
+        "type": "text"
+    }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -144,9 +144,32 @@
         "description": "A prompt shown when the user is editing an existing goal",
         "type": "text"
         },
-        "reorderGoals": "목표 순서 변경",
-        "@reorderGoals": {
-            "description": "Title or label for the screen where users can change the order of their goals",
-            "type": "text"
+    "reorderGoals": "목표 순서 변경",
+    "@reorderGoals": {
+        "description": "Title or label for the screen where users can change the order of their goals",
+        "type": "text"
+    },
+    "goalLimitTitle": "목표 개수 제한",
+    "@goalLimitTitle": {
+        "description": "Title shown when the user tries to add a goal but has reached the goal limit",
+        "type": "text"
+    },
+    "goalLimitMessage": "목표는 최대 {maxGoalCount}개까지만 등록할 수 있어요.\n새 목표를 추가하려면 기존 목표를 삭제해 주세요.",
+    "@goalLimitMessage": {
+        "description": "Message shown when the user has reached the goal creation limit.",
+        "type": "text",
+        "placeholders": {
+            "maxGoalCount": {
+                "type": "int",
+                "example": "5",
+                "description": "The maximum number of goals a user can have"
+            }
         }
+    },
+    "ok": "OK",
+    "@ok": {
+        "description": "Generic confirmation button for dismissing dialogs without performing an action",
+        "type": "text"
     }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:haenaedda/data/repositories/goal_local_repository.dart';
 import 'package:haenaedda/data/repositories/record_local_repository.dart';
 import 'package:haenaedda/data/sources/local/goal_local_data_source.dart';
 import 'package:haenaedda/data/sources/local/record_local_data_source.dart';
+import 'package:haenaedda/domain/policies/default_goal_policy.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/presentation/pages/launcher/launcher_page.dart';
 import 'package:haenaedda/presentation/view_models/calendar_month_view_model.dart';
@@ -29,7 +30,7 @@ Future<void> main() async {
   };
   final goalDataSource = GoalLocalDataSource();
   final goalRepository = GoalLocalRepository(goalDataSource);
-  final goalViewModel = GoalViewModel(goalRepository);
+  final goalViewModel = GoalViewModel(goalRepository, defaultGoalPolicy);
 
   final recordDataSource = RecordLocalDataSource();
   final recordRepository = RecordLocalRepository(recordDataSource);

--- a/lib/presentation/pages/settings/settings_bottom_modal.dart
+++ b/lib/presentation/pages/settings/settings_bottom_modal.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import 'package:haenaedda/constants/dimensions.dart';
 import 'package:haenaedda/domain/entities/goal.dart';
 import 'package:haenaedda/domain/enums/goal_setting_action.dart';
 import 'package:haenaedda/domain/enums/reset_type.dart';
+import 'package:haenaedda/domain/policies/default_goal_policy.dart';
 import 'package:haenaedda/gen_l10n/app_localizations.dart';
 import 'package:haenaedda/presentation/handlers/reset_goal_handler.dart';
 import 'package:haenaedda/presentation/pages/settings/neumorphic_settings_tile.dart';
+import 'package:haenaedda/presentation/view_models/goal_view_models.dart';
 import 'package:haenaedda/presentation/widgets/bottom_right_button.dart';
+import 'package:haenaedda/presentation/widgets/dialogs/one_button_dialog.dart';
 
 class SettingsBottomModal extends StatelessWidget {
   final Goal goal;
@@ -18,6 +22,9 @@ class SettingsBottomModal extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context)!;
+    final isUnderGoalLimit =
+        context.select((GoalViewModel viewModel) => (viewModel.isAddable));
+
     return SafeArea(
       child: Stack(
         alignment: Alignment.center,
@@ -43,8 +50,7 @@ class SettingsBottomModal extends StatelessWidget {
                 ),
                 NeumorphicSettingsTile(
                   title: l10n.addGoal,
-                  onTap: () =>
-                      Navigator.of(context).pop(GoalSettingAction.addGoal),
+                  onTap: () => _handleAddGoalTap(context, isUnderGoalLimit),
                 ),
                 NeumorphicSettingsTile(
                   title: l10n.menuResetRecordsOnly,
@@ -74,5 +80,19 @@ class SettingsBottomModal extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  Future<void> _handleAddGoalTap(BuildContext context, bool canAdd) async {
+    final l10n = AppLocalizations.of(context)!;
+    if (canAdd) {
+      showOneButtonDialog(
+        context,
+        l10n.goalLimitTitle,
+        l10n.goalLimitMessage(defaultGoalPolicy.maxGoalCount),
+        l10n.ok,
+      );
+      return;
+    }
+    Navigator.of(context).pop(GoalSettingAction.addGoal);
   }
 }

--- a/lib/presentation/view_models/goal_view_models.dart
+++ b/lib/presentation/view_models/goal_view_models.dart
@@ -3,23 +3,26 @@ import 'package:flutter/material.dart';
 import 'package:haenaedda/common/utils/goal_list_helper.dart';
 import 'package:haenaedda/domain/entities/goal.dart';
 import 'package:haenaedda/domain/enums/goal_operation_result.dart';
+import 'package:haenaedda/domain/policies/goal_policy.dart';
 import 'package:haenaedda/domain/repositories/goal_repository.dart';
 import 'package:haenaedda/extensions/iterable_extensions.dart';
 
 class GoalViewModel extends ChangeNotifier {
   final GoalRepository _goalRepository;
+  final GoalPolicy _goalPolicy;
 
   final List<Goal> _goals = [];
   List<Goal> _sortedGoals = [];
 
   bool _isLoaded = false;
 
-  GoalViewModel(this._goalRepository);
+  GoalViewModel(this._goalRepository, this._goalPolicy);
 
   List<Goal> get goals => _goals;
   List<Goal> get sortedGoals => _sortedGoals;
   bool get isLoaded => _isLoaded;
   bool get hasNoGoal => goals.isEmpty;
+  bool get isAddable => goals.length < _goalPolicy.maxGoalCount;
 
   Goal? getGoalById(String id) {
     return goals.firstWhereOrNull((g) => g.id == id);
@@ -64,6 +67,9 @@ class GoalViewModel extends ChangeNotifier {
   }
 
   Future<({AddGoalResult result, Goal? goal})> addGoal(String title) async {
+    if (goals.length >= _goalPolicy.maxGoalCount) {
+      return (result: AddGoalResult.limitExceeded, goal: null);
+    }
     final trimmedTitle = title.trim();
     if (trimmedTitle.isEmpty) {
       return (result: AddGoalResult.emptyInput, goal: null);

--- a/lib/presentation/widgets/dialogs/one_button_dialog.dart
+++ b/lib/presentation/widgets/dialogs/one_button_dialog.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import 'package:haenaedda/gen_l10n/app_localizations.dart';
+import 'package:haenaedda/theme/buttons.dart';
+
+Future<void> showOneButtonDialog(
+  BuildContext context,
+  String title,
+  String message,
+  String buttonText,
+) async {
+  final colorScheme = Theme.of(context).colorScheme;
+
+  await showGeneralDialog(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel: AppLocalizations.of(context)!.dismiss,
+    barrierColor: Colors.black.withValues(alpha: 0.2),
+    transitionDuration: const Duration(milliseconds: 300),
+    pageBuilder: (context, _, __) => Material(
+      color: Colors.transparent,
+      child: Center(
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 24),
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(24),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.08),
+                blurRadius: 20,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                title,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                message,
+                textAlign: TextAlign.center,
+                style: TextStyle(fontSize: 14, color: Colors.grey.shade700),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: TextButton(
+                        style: getNeutralButtonStyle(context),
+                        onPressed: () => Navigator.of(context).pop(),
+                        child: Text(
+                          buttonText,
+                          style: getButtonTextStyle(),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/theme/buttons.dart
+++ b/lib/theme/buttons.dart
@@ -46,7 +46,7 @@ ButtonStyle getNeutralButtonStyle(BuildContext context) {
       ? AppColors.darkSurfaceContainerHigh
       : AppColors.surfaceContainerLow;
   final foregroundColor =
-      isDark ? AppColors.darkOnSurface : AppColors.onSurfaceVariant;
+      isDark ? AppColors.darkOnSurface : AppColors.onSurface;
   return getTextButtonStyle(
     backgroundColor: backgroundColor,
     foregroundColor: foregroundColor,


### PR DESCRIPTION
## 변경 목적
- 목표 수 제한 정책 도입 
- 목표 개수 제한 도달 시 사용자에게 명확하게 안내하기 위함
- 중복 코드 없이 재사용 가능한 단일 버튼 다이얼로그 컴포넌트를 도입
- 사용자 경험(UX) 개선 및 앱 정책(GoalPolicy) 일관성 확보

## 주요 변경 사항
- showOneButtonDialog() 함수 생성 (presentation/widgets/dialogs/)
    - 제목, 메시지, 버튼 텍스트를 전달받아 단순 안내형 다이얼로그 표시
   
- GoalPolicy 도메인에 추가 (domain/policies/goal_policy.dart)
    - 최대 목표 개수 설정을 위한 정책 클래스 정의 및 defaultGoalPolicy 제공

- 목표 추가 시도 시 개수 제한 체크 로직 적용
    - 설정 페이지(GoalSettingTile)에서 목표 개수 초과 시 다이얼로그 표시
    - 초과되지 않은 경우에만 기존 동작 수행 (Navigator pop)


## 기대 효과
- 사용자에게 목표 수 제한 도달 시 명확한 피드백 제공
- 다이얼로그 구성 로직의 재사용성 향상 및 중복 제거
- GoalPolicy를 통해 앱 정책 기준의 중앙 집중 관리 가능

## 다음 계획
 - showConfirmDialog() 등 버튼 2개 이상인 다이얼로그 공통화
- 목표 관련 정책 (예: 제목 길이 제한 등) 추가 시 GoalPolicy 확장
- 다이얼로그 관련 테스트 유닛 분리 또는 UI 테스트 도입 고려